### PR TITLE
standardize TESTS and EXAMPLES

### DIFF
--- a/doc/news/standard_TESTS.rst
+++ b/doc/news/standard_TESTS.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Fixed documentation syntax, use `TESTS::` and `EXAMPLES::` like SageMath does.

--- a/surface_dynamics/databases/flat_surfaces.py
+++ b/surface_dynamics/databases/flat_surfaces.py
@@ -342,7 +342,7 @@ class CylinderDiagrams(GenericRepertoryDatabase):
         r"""
         String representation.
 
-        TEST::
+        TESTS::
 
             sage: from surface_dynamics.databases.flat_surfaces import CylinderDiagrams
             sage: C = CylinderDiagrams(tmp_dir(), read_only=False)

--- a/surface_dynamics/flat_surfaces/origamis/origami_dense.pyx
+++ b/surface_dynamics/flat_surfaces/origamis/origami_dense.pyx
@@ -2448,7 +2448,7 @@ cdef class Origami_dense_pyx:
         An origami is primitive if the action of the monodromy group has no non
         trivial block.
 
-        EXAMPLE::
+        EXAMPLES::
 
             sage: from surface_dynamics.all import Origami
 

--- a/surface_dynamics/flat_surfaces/strata.py
+++ b/surface_dynamics/flat_surfaces/strata.py
@@ -498,7 +498,7 @@ class StratumComponent(SageObject):
 
     def __init__(self, stratum):
         r"""
-        TEST::
+        TESTS::
 
             sage: from surface_dynamics import *
 

--- a/surface_dynamics/interval_exchanges/iet.py
+++ b/surface_dynamics/interval_exchanges/iet.py
@@ -135,7 +135,7 @@ class IntervalExchangeTransformation:
 
         - ``lengths`` - the list of lengths
 
-        TEST::
+        TESTS::
 
             sage: from surface_dynamics import *
 
@@ -1523,7 +1523,7 @@ class IntervalExchangeTransformation:
         - ``(a,b,c)`` - a triple of letter such that the towers are obtained by
           applying the substitution `a \mapsto bc`.
 
-        TEST::
+        TESTS::
 
             sage: from surface_dynamics import *
 
@@ -1670,7 +1670,7 @@ class IntervalExchangeTransformation:
 
         - ``m`` -- number of Rauzy made on the same side
 
-        TEST::
+        TESTS::
 
             sage: from surface_dynamics import *
 

--- a/surface_dynamics/interval_exchanges/labelled.py
+++ b/surface_dynamics/interval_exchanges/labelled.py
@@ -1187,7 +1187,7 @@ class FlippedLabelledPermutationIET(FlippedPermutationIET, LabelledPermutationIE
 
         permutation -- the associated reduced permutation
 
-        EXAMPLE::
+        EXAMPLES::
 
             sage: from surface_dynamics import *
 
@@ -1530,7 +1530,7 @@ class LabelledRauzyDiagram(RauzyDiagram):
 
             boolean -- True if the path is full and False else
 
-            EXAMPLE::
+            EXAMPLES::
 
                 sage: from surface_dynamics import *
 

--- a/surface_dynamics/interval_exchanges/reduced.py
+++ b/surface_dynamics/interval_exchanges/reduced.py
@@ -223,7 +223,7 @@ class ReducedPermutationIET(ReducedPermutation, OrientablePermutationIET):
         r"""
         Returns the relabelization obtained from this move.
 
-        EXAMPLE::
+        EXAMPLES::
 
             sage: from surface_dynamics import *
 

--- a/surface_dynamics/interval_exchanges/template.py
+++ b/surface_dynamics/interval_exchanges/template.py
@@ -5597,7 +5597,7 @@ class RauzyDiagram(SageObject):
             r"""
             Constructor of the path.
 
-            TEST::
+            TESTS::
 
                 sage: from surface_dynamics import *
 
@@ -5715,7 +5715,7 @@ class RauzyDiagram(SageObject):
             r"""
             Tests equality
 
-            TEST::
+            TESTS::
 
                 sage: from surface_dynamics import *
 
@@ -5740,7 +5740,7 @@ class RauzyDiagram(SageObject):
             r"""
             Tests inequality
 
-            TEST::
+            TESTS::
 
                 sage: from surface_dynamics import *
 
@@ -6198,7 +6198,7 @@ class RauzyDiagram(SageObject):
 
             - ``composition`` - the composition function for the function. * if None (default: None)
 
-            TEST::
+            TESTS::
 
                 sage: from surface_dynamics import *
 
@@ -6371,7 +6371,7 @@ class RauzyDiagram(SageObject):
         r"""
         Tests difference.
 
-        TEST::
+        TESTS::
 
             sage: from surface_dynamics import *
 
@@ -6827,7 +6827,7 @@ class RauzyDiagram(SageObject):
         r"""
         Return the corresponding loser
 
-        TEST::
+        TESTS::
 
             sage: from surface_dynamics import *
 
@@ -6999,7 +6999,7 @@ class RauzyDiagram(SageObject):
         r"""
         Returns a representation of self
 
-        TEST::
+        TESTS::
 
             sage: from surface_dynamics import *
 
@@ -7104,7 +7104,7 @@ class RauzyDiagram(SageObject):
         functions __getitem__ and has_rauzy_move and rauzy_move which must
         be defined for child and their corresponding permutation types.
 
-        TEST::
+        TESTS::
 
             sage: from surface_dynamics import *
 


### PR DESCRIPTION
I have just changed a few `TEST::` by `TESTS::` and the same for `EXAMPLE::` to `EXAMPLES::`.

This is to be aligned with sage standard.
