### PR TITLE
Implement strata of meromorphic and higher differentials

### DIFF
--- a/doc/news/strata.rst
+++ b/doc/news/strata.rst
@@ -1,0 +1,8 @@
+**Added:**
+
+* stratum of meromorphic and higher order differentials
+
+**Deprecated:**
+
+* methods of Stratum (and subclasses AbelianStratum, QuadraticStratum):
+  zeros(), genus(), nb_zeros(), nb_fake_zeros(), nb_poles()

--- a/doc/source/examples/rank2_genus3_classification.md
+++ b/doc/source/examples/rank2_genus3_classification.md
@@ -558,7 +558,7 @@ many partitions as possible.
 
 
 ```{code-cell}
-from surface_dynamics import AbelianStratum
+from surface_dynamics import Stratum
 from surface_dynamics.databases.flat_surfaces import CylinderDiagrams
 
 def filter_partitions(cyl_diag_list, num_classes):
@@ -583,7 +583,7 @@ two of the four cylinder diagrams. For the remaining ones, we only need to
 consider one partition each.
 
 ```{code-cell}
-H = AbelianStratum(3, 1).components()[0]
+H = Stratum([3, 1], k=1).components()[0]
 C = CylinderDiagrams()
 
 # Check the partitions with 2 classes
@@ -651,10 +651,10 @@ def list_cylinder_classes(H, num_cylinders, num_classes):
 
 
 ```{code-cell}
-# H = AbelianStratum(3, 1).components()[0]
-# H = AbelianStratum(2, 2).components()[1]         ## This is H^odd(2,2)
-H = AbelianStratum(2, 1, 1).components()[0]
-# H = AbelianStratum(1, 1, 1, 1).components()[0]
+# H = Stratum([3, 1], k=1).components()[0]
+# H = Stratum([2, 2], k=1).components()[1]         ## This is H^odd(2,2)
+H = Stratum([2, 1, 1], k=1).components()[0]
+# H = Stratum([1, 1, 1, 1], k=1).components()[0]
 
 # Cylinder diagrams with 4 or more cylinders.
 for num_cylinders in range(4, 7):

--- a/surface_dynamics/databases/flat_surfaces.py
+++ b/surface_dynamics/databases/flat_surfaces.py
@@ -130,13 +130,13 @@ class GenericRepertoryDatabase:
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
             sage: from surface_dynamics.databases.flat_surfaces import CylinderDiagrams
             sage: import tempfile
 
             sage: tmp_dir = tempfile.TemporaryDirectory()
             sage: C = CylinderDiagrams(tmp_dir.name, read_only=False)
-            sage: C.update(AbelianStratum(4))
+            sage: C.update(Stratum([4], k=1))
             sage: import os
             sage: sorted(os.listdir(C.path))
             ['cyl_diags-4-hyp-1',
@@ -180,12 +180,13 @@ class IrregularComponentTwins(GenericRepertoryDatabase):
         EXAMPLES::
 
             sage: from surface_dynamics import *
-
             sage: from surface_dynamics.databases.flat_surfaces import IrregularComponentTwins
             sage: D = IrregularComponentTwins()
-            sage: D.filename(QuadraticStratum(12))
+            sage: D.filename(Stratum([12], k=2))
             'twins-12-irr'
-            sage: D.filename(QuadraticStratum(2,2))
+            sage: D.filename(Stratum([3,3,3,-1], k=2))
+            'twins-3_3_3_p-irr'
+            sage: D.filename(Stratum([2,2], k=2))
             Traceback (most recent call last):
             ...
             AssertionError: the stratum has no irregular component
@@ -193,9 +194,11 @@ class IrregularComponentTwins(GenericRepertoryDatabase):
         from surface_dynamics.flat_surfaces.quadratic_strata import QuadraticStratum
         assert isinstance(stratum, QuadraticStratum)
         assert stratum.has_regular_and_irregular_components(), "the stratum has no irregular component"
+        sig_pos = [z for z in stratum.signature() if z >= 0]
+        np = sum(z == -1 for z in stratum.signature())
         return ('twins-' +
-                '_'.join(str(z) for z in stratum.zeros(poles=False)) +
-                '_p' * stratum.nb_poles() +
+                '_'.join(str(z) for z in sig_pos) +
+                '_p' * np +
                 '-irr')
 
     def has_stratum(self, stratum):
@@ -208,10 +211,10 @@ class IrregularComponentTwins(GenericRepertoryDatabase):
 
             sage: from surface_dynamics.databases.flat_surfaces import IrregularComponentTwins
             sage: D = IrregularComponentTwins()
-            sage: D.has_stratum(QuadraticStratum(12))
+            sage: D.has_stratum(Stratum([12], k=2))
             True
         """
-        return os.path.isfile(os.path.join(self.path,self.filename(stratum)))
+        return os.path.isfile(os.path.join(self.path, self.filename(stratum)))
 
     def update(self, stratum):
         r"""
@@ -246,7 +249,7 @@ class IrregularComponentTwins(GenericRepertoryDatabase):
             sage: G.list_strata()
             [Q_3(9, -1), Q_3(6, 3, -1), Q_4(12), Q_3(3^3, -1), Q_4(6^2), Q_4(9, 3), Q_4(6, 3^2), Q_4(3^4)]
         """
-        from surface_dynamics.flat_surfaces.quadratic_strata import QuadraticStratum
+        from surface_dynamics.flat_surfaces.quadratic_strata import Stratum
         from sage.rings.integer import Integer
         s = set()
         for f in os.listdir(self.path):
@@ -256,7 +259,7 @@ class IrregularComponentTwins(GenericRepertoryDatabase):
                 comp = g[:i].replace('p','-1')
                 s.add(comp)
 
-        return sorted(QuadraticStratum(map(Integer,g.split('_'))) for g in s)
+        return sorted(Stratum(list(map(Integer,g.split('_'))), k=2) for g in s)
 
     def get(self, stratum):
         r"""
@@ -268,7 +271,7 @@ class IrregularComponentTwins(GenericRepertoryDatabase):
 
             sage: from surface_dynamics.databases.flat_surfaces import IrregularComponentTwins
             sage: D = IrregularComponentTwins()
-            sage: l = D.get(QuadraticStratum(6,3,-1))
+            sage: l = D.get(Stratum([6,3,-1], k=2))
             sage: l[0]
             ((1, 2, 0, 4, 6, 7, 8, 9, 10, 11, 12, 13, 5, 3),)
             sage: len(l)
@@ -294,7 +297,7 @@ class IrregularComponentTwins(GenericRepertoryDatabase):
 
             sage: from surface_dynamics.databases.flat_surfaces import IrregularComponentTwins
             sage: D = IrregularComponentTwins()
-            sage: Q = QuadraticStratum(12)
+            sage: Q = Stratum([12], k=2)
             sage: len(D.get(Q))
             82
             sage: D.count(Q)
@@ -312,12 +315,12 @@ class CylinderDiagrams(GenericRepertoryDatabase):
 
     EXAMPLES::
 
-        sage: from surface_dynamics import *
+        sage: from surface_dynamics import Stratum
         sage: from surface_dynamics.databases.flat_surfaces import CylinderDiagrams
         sage: import os
 
         sage: C = CylinderDiagrams()
-        sage: a = AbelianStratum(3,1,1,1).unique_component()
+        sage: a = Stratum([3,1,1,1], k=1).unique_component()
         sage: C.filename(a, 2)
         'cyl_diags-3_1_1_1-c-2'
         sage: os.path.isfile(os.path.join(C.path, C.filename(a, 2)))
@@ -352,16 +355,16 @@ class CylinderDiagrams(GenericRepertoryDatabase):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
             sage: from surface_dynamics.databases.flat_surfaces import CylinderDiagrams
             sage: C = CylinderDiagrams()
-            sage: C.filename(AbelianStratum(4).odd_component(), 3)
+            sage: C.filename(Stratum([4], k=1).odd_component(), 3)
             'cyl_diags-4-odd-3'
-            sage: C.filename(AbelianStratum(3,3).hyperelliptic_component(), 2)
+            sage: C.filename(Stratum([3,3], k=1).hyperelliptic_component(), 2)
             'cyl_diags-3_3-hyp-2'
         """
         return ('cyl_diags-' +
-                '_'.join(str(z) for z in comp.stratum().zeros()) +
+                '_'.join(str(z) for z in comp.stratum().signature()) +
                 '-' + comp._name +
                 '-' + str(ncyls))
 
@@ -371,7 +374,7 @@ class CylinderDiagrams(GenericRepertoryDatabase):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
             sage: from surface_dynamics.databases.flat_surfaces import CylinderDiagrams
             sage: import tempfile
 
@@ -379,14 +382,14 @@ class CylinderDiagrams(GenericRepertoryDatabase):
             sage: C = CylinderDiagrams(tmp_dir.name, read_only=False)
             sage: C.clean()
 
-            sage: a1 = AbelianStratum(4).odd_component()
-            sage: a2 = AbelianStratum(1,1,1,1).unique_component()
+            sage: a1 = Stratum([4], k=1).odd_component()
+            sage: a2 = Stratum([1,1,1,1], k=1).unique_component()
 
             sage: C.has_component(a1)
             False
             sage: C.has_component(a2)
             False
-            sage: C.update(AbelianStratum(4))
+            sage: C.update(Stratum([4], k=1))
             sage: C.has_component(a1)
             True
 
@@ -409,22 +412,22 @@ class CylinderDiagrams(GenericRepertoryDatabase):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
-
+            sage: from surface_dynamics import Stratum
             sage: from surface_dynamics.databases.flat_surfaces import CylinderDiagrams
+
             sage: import os
 
             sage: C = CylinderDiagrams(tmp_dir(), read_only=False)
             sage: C.clean()
 
-            sage: a1 = AbelianStratum(4)
-            sage: a2 = AbelianStratum(1,1,1,1)
+            sage: a1 = Stratum([4], k=1)
+            sage: a2 = Stratum([1,1,1,1], k=1)
 
             sage: C.has_stratum(a1)
             False
             sage: C.has_stratum(a2)
             False
-            sage: C.update(AbelianStratum(4))
+            sage: C.update(Stratum([4], k=1))
             sage: C.has_stratum(a1)
             True
 
@@ -467,8 +470,7 @@ class CylinderDiagrams(GenericRepertoryDatabase):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
-
+            sage: from surface_dynamics import Stratum
             sage: from surface_dynamics.databases.flat_surfaces import CylinderDiagrams
             sage: import os
 
@@ -477,21 +479,21 @@ class CylinderDiagrams(GenericRepertoryDatabase):
 
             sage: C.list_strata()
             []
-            sage: C.update(AbelianStratum(1,1))
+            sage: C.update(Stratum([1,1], k=1))
             sage: C.list_strata()
             [H_2(1^2)]
-            sage: C.update(AbelianStratum(2))
+            sage: C.update(Stratum([2], k=1))
             sage: C.list_strata()
             [H_2(2), H_2(1^2)]
         """
-        from surface_dynamics.flat_surfaces.abelian_strata import AbelianStratum
+        from surface_dynamics.flat_surfaces.abelian_strata import Stratum
         from sage.rings.integer import Integer
         s = set()
         for f in self._files():
             g = f[10:]
             s.add(g[:g.index('-')])
 
-        return [AbelianStratum(map(Integer, g.split('_'))) for g in sorted(s, reverse=True)]
+        return [Stratum(tuple(map(Integer, g.split('_'))), k=1) for g in sorted(s, reverse=True)]
 
     def get_iterator(self, comp, ncyls=None):
         r"""
@@ -506,14 +508,13 @@ class CylinderDiagrams(GenericRepertoryDatabase):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
-
+            sage: from surface_dynamics import Stratum
             sage: from surface_dynamics.databases.flat_surfaces import CylinderDiagrams
             sage: import os
 
             sage: C = CylinderDiagrams(tmp_dir(), read_only=False)
 
-            sage: A = AbelianStratum(2)
+            sage: A = Stratum([2], k=1)
             sage: a = A.unique_component()
             sage: C.update(A)
             sage: list(C.get_iterator(a)) == A.cylinder_diagrams()
@@ -532,8 +533,8 @@ class CylinderDiagrams(GenericRepertoryDatabase):
 
         if ncyls is None:
             from itertools import chain
-            g = comp.stratum().genus()
-            s = comp.stratum().nb_zeros()
+            g = comp.stratum().surface_genus()
+            s = len(comp.stratum().signature())
             return chain(*(self.get_iterator(comp,i) for i in range(1,g+s)))
 
         filename = os.path.join(self.path, self.filename(comp,ncyls))
@@ -632,12 +633,11 @@ class CylinderDiagrams(GenericRepertoryDatabase):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
-
+            sage: from surface_dynamics import Stratum
             sage: from surface_dynamics.databases.flat_surfaces import CylinderDiagrams
 
             sage: C = CylinderDiagrams(tmp_dir(), read_only=False)
-            sage: C.update(AbelianStratum(4), verbose=True) # random
+            sage: C.update(Stratum([4], k=1), verbose=True) # random
             computation for H_3(4)
              ncyls = 1
              1 cyl. diags for H_3(4)^hyp
@@ -662,7 +662,7 @@ class CylinderDiagrams(GenericRepertoryDatabase):
             print("computation for %s"%stratum)
             sys.stdout.flush()
 
-        for ncyls in range(1, stratum.genus() + stratum.nb_zeros()):
+        for ncyls in range(1, stratum.surface_genus() + len(stratum.signature())):
             if verbose:
                 print(" ncyls = %d"%ncyls)
                 sys.stdout.flush()
@@ -686,8 +686,8 @@ class CylinderDiagrams(GenericRepertoryDatabase):
             return sum(self.count(cc, ncyls) for cc in comp.components())
 
         if ncyls is None:
-            g = comp.stratum().genus()
-            s = comp.stratum().nb_zeros()
+            g = comp.stratum().surface_genus()
+            s = len(comp.stratum().signature())
             return sum((self.count(comp,i) for i in range(1,g+s)))
 
         return line_count(os.path.join(self.path, self.filename(comp, ncyls)))

--- a/surface_dynamics/flat_surfaces/abelian_strata.py
+++ b/surface_dynamics/flat_surfaces/abelian_strata.py
@@ -2069,7 +2069,7 @@ class HypAbelianStratumComponent(ASC):
             Rauzy diagram with 20 permutations
         """
         g = self._stratum.surface_genus()
-        n = self._stratum.nb_fake_zeros()
+        n = self._stratum.signature().count(0)
         m = sum(x != 0 for x in self._stratum.signature())
 
         if left_degree is not None:
@@ -2241,7 +2241,7 @@ class HypAbelianStratumComponent(ASC):
                     ((left_degree+1) * zeros.count(left_degree)) *
                     self.rauzy_class_cardinality(left_degree=left_degree,reduced=True))
 
-        k = self.stratum().nb_fake_zeros()
+        k = self.stratum().signature().count(0)
         dd = self.stratum().dimension()  # it is d+k
         d = dd-k
 
@@ -2261,7 +2261,7 @@ class HypAbelianStratumComponent(ASC):
         r"""
         In hyperelliptic component there is only one standard permutation.
         """
-        if not self.stratum().nb_fake_zeros():
+        if 0 not in self.stratum().signature():
             return self.permutation_representative()
 
         raise NotImplementedError("not implemented when there are fake zeros")
@@ -2278,7 +2278,7 @@ class HypAbelianStratumComponent(ASC):
             [0 1 2 3 4 5 6 7
              7 6 5 4 3 2 1 0]
         """
-        if not self.stratum().nb_fake_zeros():
+        if 0 not in self.stratum().signature():
             d = self.stratum().dimension()
             l0 = list(range(d))
             l1 = list(range(d-1,-1,-1))
@@ -2299,7 +2299,7 @@ class HypAbelianStratumComponent(ASC):
         Return the number of standard permutations in this hyperelliptic
         component.
         """
-        if not self.stratum().nb_fake_zeros():
+        if 0 not in self.stratum().signature():
             return Integer(1)
 
         raise NotImplementedError("not implemented when there are fake zeros")
@@ -2342,7 +2342,7 @@ class HypAbelianStratumComponent(ASC):
 
         stratum = self.stratum()
 
-        if stratum.nb_fake_zeros():
+        if 0 in stratum.signature():
             raise ValueError("the stratum has fake zeros")
 
         z = stratum.signature()
@@ -2947,7 +2947,7 @@ class EvenAbelianStratumComponent(ASC):
 
         fk_zeros_perm = GeneralizedPermutation([0],[0])
         mk_pt_perm = GeneralizedPermutation([0,1],[1,0])
-        for i in range(self.stratum().nb_fake_zeros()):
+        for i in range(self.stratum().signature().count(0)):
             fk_zeros_perm = cylinder_concatenation(fk_zeros_perm,mk_pt_perm)
 
         two_count = real_zeros.count(2)
@@ -3341,7 +3341,7 @@ class OddAbelianStratumComponent(ASC):
 
         fk_zeros_perm = GeneralizedPermutation([0],[0])
         mk_pt_perm = GeneralizedPermutation([0,1],[1,0])
-        for i in range(self.stratum().nb_fake_zeros()):
+        for i in range(self.stratum().signature().count(0)):
             fk_zeros_perm = cylinder_concatenation(fk_zeros_perm,mk_pt_perm)
 
         two_count = real_zeros.count(2)
@@ -3567,7 +3567,7 @@ class AbelianStrata(Strata):
 
         return ((self._genus is None or c.surface_genus() == self._genus) and
                 (self._dimension is None or c.dimension() == self._dimension) and
-                (self._fake_zeros is None or self._fake_zeros or not c.nb_fake_zeros()))
+                (self._fake_zeros is None or self._fake_zeros or not c.signature().count(0)))
 
 
 class AbelianStrata_g(AbelianStrata):

--- a/surface_dynamics/flat_surfaces/abelian_strata.py
+++ b/surface_dynamics/flat_surfaces/abelian_strata.py
@@ -58,30 +58,30 @@ EXAMPLES:
 
 Construction of a stratum from a list of singularity degrees::
 
-    sage: a = AbelianStratum(1,1)
+    sage: a = Stratum([1,1], k=1)
     sage: a
     H_2(1^2)
-    sage: a.genus()
+    sage: a.surface_genus()
     2
     sage: a.dimension()
     5
 
 ::
 
-    sage: a = AbelianStratum(4,3,2,1)
+    sage: a = Stratum([4,3,2,1], k=1)
     sage: a
     H_6(4, 3, 2, 1)
-    sage: a.genus()
+    sage: a.surface_genus()
     6
     sage: a.dimension()
     15
 
 By convention, the degrees are always written in decreasing order::
 
-    sage: a1 = AbelianStratum(4,3,2,1)
+    sage: a1 = Stratum([4,3,2,1], k=1)
     sage: a1
     H_6(4, 3, 2, 1)
-    sage: a2 = AbelianStratum(2,3,1,4)
+    sage: a2 = Stratum([2,3,1,4], k=1)
     sage: a2
     H_6(4, 3, 2, 1)
     sage: a1 == a2
@@ -89,8 +89,8 @@ By convention, the degrees are always written in decreasing order::
 
 It is possible to lis strata and their connected components::
 
-    sage: AbelianStratum(10).components()
-    [H_6(10)^hyp, H_6(10)^odd, H_6(10)^even]
+    sage: Stratum([10], k=1).components()
+    (H_6(10)^hyp, H_6(10)^odd, H_6(10)^even)
 
 Get a list of strata with constraints on genus or on the number of intervals
 of a representative::
@@ -100,9 +100,9 @@ of a representative::
 
 Obtains the connected components of a stratum::
 
-    sage: a = AbelianStratum(0)
+    sage: a = Stratum([0], k=1)
     sage: a.components()
-    [H_1(0)^hyp]
+    (H_1(0)^hyp,)
 
 ::
 
@@ -119,7 +119,7 @@ Obtains the connected components of a stratum::
     sage: N = 0
     sage: for a in A:
     ....:    for cc in a.components():
-    ....:       for z in set(a.zeros()):
+    ....:       for z in set(a.signature()):
     ....:           p = cc.permutation_representative(left_degree=z)
     ....:           n = p.rauzy_diagram().cardinality()
     ....:           print("%13s, %d  :  %d"%(cc, z, n))
@@ -214,6 +214,43 @@ def _cylinder_diagrams_with_symmetric(iterator):
         else:
             raise RuntimeError
 
+
+def DeprecatedAbelianStratumConstructor(*l):
+    """
+    TESTS::
+
+        sage: from surface_dynamics import AbelianStratum, Stratum
+
+        sage: s = AbelianStratum(0)
+        doctest:warning
+        ...
+        UserWarning: AbelianStratum has changed its arguments in order to handle meromorphic and higher-order differentials; use Stratum instead
+        sage: s is loads(dumps(s))
+        True
+
+        sage: AbelianStratum(1,1,1,1) is AbelianStratum(1,1,1,1)
+        True
+        sage: AbelianStratum(1,1,1,1) is Stratum((1, 1, 1, 1), 1)
+        True
+    """
+    import warnings
+
+    warnings.warn('AbelianStratum has changed its arguments in order to handle meromorphic and higher-order differentials; use Stratum instead')
+
+    if len(l) == 1:
+        try:
+            Integer(l[0])
+        except TypeError:
+            l = l[0]
+    elif len(l) == 2 and isinstance(l[0], (tuple,list)) and isinstance(1, numbers.Integral):
+        l = tuple(l[0]) + (0,) * l[1]
+    if isinstance(l, dict):
+        l = sum(([i] * mult for i, mult in l.items()), [])
+
+    l = tuple(sorted(map(Integer, l), reverse=True))
+    return Stratum(l, 1)
+
+
 class AbelianStratum(Stratum):
     """
     Stratum of Abelian differentials.
@@ -240,15 +277,15 @@ class AbelianStratum(Stratum):
 
     Creation of an Abelian stratum and get its connected components::
 
-        sage: a = AbelianStratum(2, 2)
+        sage: a = Stratum((2, 2), k=1)
         sage: a
         H_3(2^2)
         sage: a.components()
-        [H_3(2^2)^hyp, H_3(2^2)^odd]
+        (H_3(2^2)^hyp, H_3(2^2)^odd)
 
     Get a permutation representative of a connected component::
 
-        sage: a = AbelianStratum(2,2)
+        sage: a = Stratum((2,2), k=1)
         sage: a_hyp, a_odd = a.components()
         sage: a_hyp.permutation_representative()
         0 1 2 3 4 5 6
@@ -266,229 +303,27 @@ class AbelianStratum(Stratum):
     _name = 'H'
     _latex_name = '\\mathcal{H}'
 
-    @staticmethod
-    def __classcall_private__(self, *l):
-        if len(l) == 1:
-            try:
-                Integer(l[0])
-            except TypeError:
-                l = l[0]
-        elif len(l) == 2 and isinstance(l[0], (tuple,list)) and isinstance(1, numbers.Integral):
-            l = tuple(l[0]) + (0,) * l[1]
-
-        if isinstance(l, dict):
-            l = sum(([v]*e for v,e in iteritems(l)), [])
-
-        zeros = list(map(Integer, filter(lambda x: x, l)))
-        if any(z < 0 for z in zeros):
-            raise ValueError("the degrees must be non negative")
-        nb_fake_zeros = sum(1 for x in l if not x)
-        zeros.sort(reverse=True)
-        zeros = tuple(zeros)
-
-        s = sum(zeros)
-        if s%2:
-            raise ValueError("the sum of the degrees must be even")
-
-        if not zeros and not nb_fake_zeros:
-            raise ValueError("there must be at least one zero")
-
-        return UniqueRepresentation.__classcall__(AbelianStratum, zeros, nb_fake_zeros)
-
-    def __init__(self, zeros, nb_fake_zeros):
-        """
-        TESTS::
-
-            sage: from surface_dynamics import *
-
-            sage: s = AbelianStratum(0)
-            sage: s == loads(dumps(s))
-            True
-            sage: s = AbelianStratum(1,1,1,1)
-            sage: s == loads(dumps(s))
-            True
-        """
-        self._zeros = zeros
-        self._nb_fake_zeros = nb_fake_zeros
-
-        s = sum(self._zeros)
-        if s%2:
-            raise ValueError("the sum of the degrees must be even")
-        genus = s//2 + 1
-
-        if genus == 1:
-            self._cc = (HypASC,)
-
-        elif genus == 2:
-            self._cc = (HypASC,)
-
-        elif genus == 3:
-            if zeros == (2, 2) or zeros == (4,):
-                self._cc = (HypASC, OddASC)
-            else:
-                self._cc = (ASC,)
-
-        elif len(zeros) == 1:
-            # just one zeros [2g-2]
-            self._cc = (HypASC, OddASC, EvenASC)
-
-        elif zeros == (genus-1, genus-1):
-            # two similar zeros [g-1, g-1]
-            if genus % 2 == 0:
-                self._cc = (HypASC, NonHypASC)
-
-            else:
-                self._cc = (HypASC, OddASC, EvenASC)
-
-        elif all(x%2 == 0 for x in zeros):
-            # even zeroes [2 l_1, 2 l_2, ..., 2 l_n]
-            self._cc = (OddASC, EvenASC)
-
-        else:
-            # connected
-            self._cc = (ASC, )
-
-    def zeros(self, fake_zeros=True):
-        r"""
-        Return the multiplicities of the zeros.
-
-        EXAMPLES::
-
-            sage: from surface_dynamics import *
-
-            sage: AbelianStratum([1,2,3]).zeros()
-            (3, 2, 1)
-            sage: AbelianStratum({2:4}).zeros()
-            (2, 2, 2, 2)
-        """
-        if fake_zeros:
-            return self._zeros + (0,)*self._nb_fake_zeros
-        return self._zeros
-
-    def nb_zeros(self, fake_zeros=True):
-        r"""
-        Returns the number of zeros of self.
-
-        EXAMPLES::
-
-            sage: from surface_dynamics import *
-
-            sage: AbelianStratum(0).nb_zeros()
-            1
-            sage: AbelianStratum({2:4,3:2}).nb_zeros()
-            6
-        """
-        if fake_zeros:
-            return len(self._zeros) + self._nb_fake_zeros
-        return len(self._zeros)
-
-    def nb_fake_zeros(self):
-        r"""
-        Return the number of fake zeros.
-
-        EXAMPLES::
-
-            sage: from surface_dynamics import *
-
-            sage: AbelianStratum(0).nb_fake_zeros()
-            1
-            sage: AbelianStratum(1,1,0,0).nb_fake_zeros()
-            2
-
-            sage: QuadraticStratum(0,4,2,2).nb_fake_zeros()
-            1
-        """
-        return self._nb_fake_zeros
-
-    def genus(self):
-        r"""
-        Return the genus of the stratum.
-
-        OUTPUT:
-
-        integer -- the genus
-
-        EXAMPLES::
-
-            sage: from surface_dynamics import *
-
-            sage: AbelianStratum(0).genus()
-            1
-            sage: AbelianStratum(1,1).genus()
-            2
-            sage: AbelianStratum(3,2,1).genus()
-            4
-        """
-        return Integer(sum(self._zeros)//2+1)
-
-    def dimension(self):
-        r"""
-        Return the complex dimension of this stratum.
-
-        The dimension is `2g-2+s+1` where `g` is the genus of surfaces in the
-        stratum, `s` the number of singularities. The complex dimension of a
-        stratum is also the number of intervals of any interval exchange
-        transformations associated to the strata.
-
-        EXAMPLES::
-
-            sage: from surface_dynamics import *
-
-            sage: AbelianStratum(0).dimension()
-            2
-            sage: AbelianStratum(0,0).dimension()
-            3
-            sage: AbelianStratum(2).dimension()
-            4
-            sage: AbelianStratum(1,1).dimension()
-            5
-
-        ::
-
-            sage: a = AbelianStratum(4,3,2,1,0)
-            sage: p = a.permutation_representative()
-            sage: len(p) == a.dimension()
-            True
-        """
-        return 2 * self.genus() + self.nb_zeros() - 1
-
-    def rank(self):
-        r"""
-        Return the rank of this manifold (half dimension of the absolute part of the tangent space).
-
-        EXAMPLES::
-
-            sage: from surface_dynamics import AbelianStratum
-
-            sage: AbelianStratum(0,0).rank()
-            1
-            sage: AbelianStratum(2).rank()
-            2
-            sage: AbelianStratum(2,0,0).rank()
-            2
-        """
-        return self.genus()
-
-    #
-    # Connected component
-    #
-
     def has_odd_component(self):
         r"""
         Test whether this stratum has an odd spin component.
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: AbelianStratum(2).has_odd_component()
+            sage: Stratum((2,), k=1).has_odd_component()
             False
-            sage: AbelianStratum(4).has_odd_component()
+            sage: Stratum((4,), k=1).has_odd_component()
             True
-            sage: AbelianStratum(4).odd_component()
+            sage: Stratum((4,), k=1).odd_component()
             H_3(4)^odd
+
+            sage: Stratum((0,), k=1).has_odd_component()
+            False
         """
-        return all(z%2 == 0 for z in self.zeros()) and self.genus() != 2
+        if any(z < 0 for z in self.signature()):
+            raise NotImplementedError('meromorphic stratum')
+        return all(z % 2 == 0 for z in self.signature()) and self.surface_genus() >= 3
 
     def has_even_component(self):
         r"""
@@ -496,16 +331,21 @@ class AbelianStratum(Stratum):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: AbelianStratum(2,2).has_even_component()
+            sage: Stratum((2,2), k=1).has_even_component()
             False
-            sage: AbelianStratum(6).has_even_component()
+            sage: Stratum((6,), k=1).has_even_component()
             True
-            sage: AbelianStratum(6).even_component()
+            sage: Stratum((6,), k=1).even_component()
             H_4(6)^even
+
+            sage: Stratum((0,), k=1).has_even_component()
+            False
         """
-        return all(z%2 == 0 for z in self.zeros()) and self.genus() >= 4
+        if any(z < 0 for z in self.signature()):
+            raise NotImplementedError('meromorphic stratum')
+        return all(z % 2 == 0 for z in self.signature()) and self.surface_genus() >= 4
 
     def has_hyperelliptic_component(self):
         r"""
@@ -513,17 +353,23 @@ class AbelianStratum(Stratum):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: AbelianStratum(2,1,1).has_hyperelliptic_component()
+            sage: Stratum((2,1,1), k=1).has_hyperelliptic_component()
             False
-            sage: AbelianStratum(2,2).has_hyperelliptic_component()
+            sage: Stratum((2,2), k=1).has_hyperelliptic_component()
             True
-            sage: AbelianStratum(2,2).hyperelliptic_component()
+            sage: Stratum((0,0,0), k=1).has_hyperelliptic_component()
+            True
+            sage: Stratum((2,0), k=1).has_hyperelliptic_component()
+            True
+            sage: Stratum((2,2), k=1).hyperelliptic_component()
             H_3(2^2)^hyp
         """
-        z = self.zeros()
-        return len(z) == 1 or (len(z) == 2 and z[0] == z[1])
+        if any(z < 0 for z in self.signature()):
+            raise NotImplementedError('meromorphic stratum')
+        z = [z for z in self.signature() if z > 0]
+        return len(z) <= 1 or (len(z) == 2 and z[0] == z[1])
 
     def has_non_hyperelliptic_component(self):
         r"""
@@ -531,33 +377,41 @@ class AbelianStratum(Stratum):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: AbelianStratum(1,1).has_non_hyperelliptic_component()
+            sage: Stratum((1,1), k=1).has_non_hyperelliptic_component()
             False
-            sage: AbelianStratum(3,3).has_non_hyperelliptic_component()
+            sage: Stratum((3,3), k=1).has_non_hyperelliptic_component()
             True
-            sage: AbelianStratum(3,3).non_hyperelliptic_component()
+            sage: Stratum((3,3,0), k=1).has_non_hyperelliptic_component()
+            True
+
+            sage: Stratum((3,3), k=1).non_hyperelliptic_component()
             H_4(3^2)^nonhyp
         """
-        z = self.zeros()
-        return len(z) == 2 and z[0] == z[1] and z[0]%2 == 1 and z[0] > 1
+        if any(z < 0 for z in self.signature()):
+            raise NotImplementedError('meromorphic stratum')
+        z = [z for z in self.signature() if z > 0]
+        return len(z) == 2 and z[0] == z[1] and z[0] % 2 == 1 and z[0] > 1
 
+    # TODO: redesign this!!!
     def odd_component(self):
         r"""
         Return the odd component of self (if any).
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: a = AbelianStratum([2,2]); a
+            sage: a = Stratum([2,2], k=1)
+            sage: a
             H_3(2^2)
             sage: a.odd_component()
             H_3(2^2)^odd
         """
-        if OddASC in self._cc: return OddASC(self)
-        raise ValueError("No odd spin component in this stratum")
+        if not self.has_odd_component():
+            raise ValueError("No odd spin component in this stratum")
+        return OddASC(self)
 
     def even_component(self):
         r"""
@@ -565,15 +419,17 @@ class AbelianStratum(Stratum):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: a = AbelianStratum({2:4}); a
+            sage: a = Stratum({2:4}, k=1)
+            sage: a
             H_5(2^4)
             sage: a.even_component()
             H_5(2^4)^even
         """
-        if EvenASC in self._cc: return EvenASC(self)
-        raise ValueError("No even spin component in this stratum")
+        if not self.has_even_component():
+            raise ValueError("No even spin component in this stratum")
+        return EvenASC(self)
 
     def hyperelliptic_component(self):
         r"""
@@ -581,15 +437,17 @@ class AbelianStratum(Stratum):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: a = AbelianStratum(10); a
+            sage: a = Stratum([10], k=1)
+            sage: a
             H_6(10)
             sage: a.hyperelliptic_component()
             H_6(10)^hyp
         """
-        if HypASC in self._cc: return HypASC(self)
-        raise ValueError("No hyperelliptic component in this stratum")
+        if not self.has_hyperelliptic_component():
+            raise ValueError("No hyperelliptic component in this stratum")
+        return HypASC(self)
 
     def non_hyperelliptic_component(self):
         r"""
@@ -597,20 +455,23 @@ class AbelianStratum(Stratum):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: a = AbelianStratum(3,3); a
+            sage: a = Stratum((3,3), k=1)
+            sage: a
             H_4(3^2)
             sage: a.non_hyperelliptic_component()
             H_4(3^2)^nonhyp
         """
-        if NonHypASC in self._cc: return NonHypASC(self)
-        raise ValueError("No non hyperelliptic component in this stratum")
+        if not self.has_non_hyperelliptic_component():
+            raise ValueError("No non hyperelliptic component in this stratum")
+        return NonHypASC(self)
 
     #
     # Quadratic cover
     #
 
+    # TODO: this should also be done for higher order differentials
     def orientation_quotients(self, fake_zeros=False):
         r"""
         Return the list of quadratic strata such that their orientation cover
@@ -621,7 +482,7 @@ class AbelianStratum(Stratum):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
         The stratum H(2g-2) has one conic singularities of angle `2(2g-1)pi`. The
         only way a surface in H(2g-2) covers a quadratic differential is that
@@ -629,30 +490,31 @@ class AbelianStratum(Stratum):
         angle `(2g-1) \pi`. The number of poles may vary and give a collection
         of possibilities::
 
-            sage: AbelianStratum(2).orientation_quotients()
+            sage: Stratum([2], k=1).orientation_quotients()
             [Q_0(1, -1^5)]
-            sage: AbelianStratum(4).orientation_quotients()
+            sage: Stratum([4], k=1).orientation_quotients()
             [Q_1(3, -1^3), Q_0(3, -1^7)]
-            sage: AbelianStratum(6).orientation_quotients()
+            sage: Stratum([6], k=1).orientation_quotients()
             [Q_2(5, -1), Q_1(5, -1^5), Q_0(5, -1^9)]
 
         A stratum with two zeros may or may not have orientation quotients::
 
-            sage: AbelianStratum(1,1).orientation_quotients()
+            sage: Stratum([1,1], k=1).orientation_quotients()
             [Q_1(2, -1^2), Q_0(2, -1^6)]
-            sage: AbelianStratum(2,2).orientation_quotients()
+            sage: Stratum([2,2], k=1).orientation_quotients()
             [Q_1(1^2, -1^2), Q_0(1^2, -1^6), Q_1(4, -1^4), Q_0(4, -1^8)]
-            sage: AbelianStratum(3,1).orientation_quotients()
+            sage: Stratum([3,1], k=1).orientation_quotients()
             []
 
         To impose that covering of poles are fake zeros, switch option
         ``fake_zeros`` to ``True``::
 
-            sage: AbelianStratum(2,2,0,0).orientation_quotients(fake_zeros=True)
+            sage: Stratum([2,2,0,0], k=1).orientation_quotients(fake_zeros=True)
             [Q_1(1^2, -1^2)]
         """
         e = {}
-        for i in self.zeros(fake_zeros=False):
+        z = tuple(m for m in self.signature() if m)
+        for i in z:
             if i not in e: e[i] = 0
             e[i] += 1
 
@@ -662,30 +524,31 @@ class AbelianStratum(Stratum):
             return []
 
         pairings = []
-        for d,m in iteritems(e):
-            if d%2: # if the degree is odd it is necessarily non ramified
-                pairings.append([(d,m//2)])
+        for d, m in iteritems(e):
+            if d % 2: # if the degree is odd it is necessarily non ramified
+                pairings.append([(d, m//2)])
             else: # if the degree is even ramified and non ramified are possible
-                pairings.append([(d,k) for k in range(m//2+1)])
+                pairings.append([(d, k) for k in range(m//2 + 1)])
 
         import itertools
-        from .quadratic_strata import QuadraticStratum
         res = []
 
         for p in itertools.product(*pairings):
-            ee = dict((d-1,0) for d in e)
-            ee.update((2*d,0) for d in e)
+            ee = dict((d - 1, 0) for d in e)
+            ee.update((2 * d, 0) for d in e)
             for d,m in p:
-                ee[d-1] += e[d]-2*m
-                ee[2*d] += m
+                ee[d - 1] += e[d] - 2 * m
+                ee[2 * d] += m
 
             degrees = []
-            for d in ee: degrees.extend([d]*ee[d])
+            for d in ee: degrees.extend([d] * ee[d])
 
             s = sum(degrees)
-            for nb_poles in range(s%4,s+5,4):
-                q = QuadraticStratum(degrees + [-1]*nb_poles)
-                if not q.is_empty() and (not fake_zeros or q.nb_poles() <= self.nb_fake_zeros()):
+            self_nb_fake_zeros = self.signature().count(0)
+            for nb_poles in range(s % 4, s + 5, 4):
+                q = Stratum(degrees + [-1] * nb_poles, k=2)
+                q_nb_poles = q.signature().count(-1)
+                if not q.is_empty() and (not fake_zeros or q_nb_poles <= self_nb_fake_zeros):
                     res.append(q)
 
         return res
@@ -694,6 +557,7 @@ class AbelianStratum(Stratum):
     # Separatrix and cylinder diagrams
     #
 
+    # TODO: to be removed. Make separatrix_diagrams an iterator.
     def separatrix_diagram_iterator(self, ncyls=None):
         r"""
         Return an iterator over the separatrix diagrams of this stratum.
@@ -706,7 +570,7 @@ class AbelianStratum(Stratum):
         - ``ncyls`` -- an optional number of cylinders
         """
         from .separatrix_diagram import separatrix_diagram_iterator
-        return separatrix_diagram_iterator([m+1 for m in self.zeros()],ncyls)
+        return separatrix_diagram_iterator([m+1 for m in self.signature()],ncyls)
 
     def separatrix_diagrams(self, ncyls=None):
         r"""
@@ -719,9 +583,10 @@ class AbelianStratum(Stratum):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: a = AbelianStratum(2); a
+            sage: a = Stratum([2], k=1)
+            sage: a
             H_2(2)
             sage: for s in a.separatrix_diagrams(): print(s)
             (0,1,2)-(0,1,2)
@@ -729,10 +594,10 @@ class AbelianStratum(Stratum):
 
         TESTS::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
             sage: for (zeros, ncyl) in [((4,), 3), ((2,2), 4)]:
-            ....:     S = AbelianStratum(4).separatrix_diagrams(3)
+            ....:     S = Stratum(zeros, k=1).separatrix_diagrams(3)
             ....:     for i in range(len(S)):
             ....:         for j in range(i):
             ....:              assert not S[i].is_isomorphic(S[j])
@@ -758,9 +623,9 @@ class AbelianStratum(Stratum):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum, CylinderDiagram
 
-            sage: A = AbelianStratum(4)
+            sage: A = Stratum([4], k=1)
             sage: C1 = [CylinderDiagram('(0,2,1)-(0,3,4) (3)-(2) (4)-(1)'),
             ....:       CylinderDiagram('(0,2,1)-(0,3,4) (3)-(1) (4)-(2)'),
             ....:       CylinderDiagram('(0,1)-(0,3,4) (2,3)-(1) (4)-(2)'),
@@ -787,7 +652,7 @@ class AbelianStratum(Stratum):
         if ncyls is not None:
             if not isinstance(ncyls, numbers.Integral):
                 raise TypeError("ncyls should be None or an integer")
-            if ncyls < 0 or ncyls > self.genus() + self.nb_zeros() - 1:
+            if ncyls < 0 or ncyls > self.surface_genus() + len(self.signature()) - 1:
                 raise ValueError("ncyls is not valid")
 
         if not force_computation:
@@ -816,9 +681,9 @@ class AbelianStratum(Stratum):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum, CylinderDiagram
 
-            sage: A = AbelianStratum(2,2)
+            sage: A = Stratum([2,2], k=1)
             sage: C1 = [CylinderDiagram('(0,1)-(0,5) (2)-(4) (3,4)-(1) (5)-(2,3)'),
             ....:       CylinderDiagram('(0,2,1)-(3,4,5) (3)-(1) (4)-(2) (5)-(0)'),
             ....:       CylinderDiagram('(0,2,1)-(3,5,4) (3)-(1) (4)-(2) (5)-(0)'),
@@ -849,16 +714,16 @@ class AbelianStratum(Stratum):
         Recovering the multiplicity of the symmetric versions::
 
             sage: total = 0
-            sage: for c in AbelianStratum(2,1,1).cylinder_diagrams(2):
+            sage: for c in Stratum([2,1,1], k=1).cylinder_diagrams(2):
             ....:     total += 4 // (1 + sum(c.symmetries()))
             sage: total
             61
-            sage: len(AbelianStratum(2, 1, 1).cylinder_diagrams(2, up_to_symmetry=False))
+            sage: len(Stratum([2, 1, 1], k=1).cylinder_diagrams(2, up_to_symmetry=False))
             61
 
         You obtain the same number directly::
 
-            sage: AbelianStratum(2, 1, 1).cylinder_diagrams_number(2, up_to_symmetry=False)
+            sage: Stratum([2, 1, 1], k=1).cylinder_diagrams_number(2, up_to_symmetry=False)
             61
         """
         return sorted(self.cylinder_diagram_iterator(ncyls, up_to_symmetry, force_computation))
@@ -879,9 +744,9 @@ class AbelianStratum(Stratum):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: A = AbelianStratum(4)
+            sage: A = Stratum([4], k=1)
             sage: cyls = A.cylinder_diagrams_by_component(ncyls=2, force_computation=True)
             sage: A_hyp = A.hyperelliptic_component()
             sage: A_odd = A.odd_component()
@@ -910,7 +775,7 @@ class AbelianStratum(Stratum):
         if ncyls is not None:
             if not isinstance(ncyls, (int,Integer)):
                 raise TypeError("ncyls should be None or an integer")
-            if ncyls < 0 or ncyls > self.genus() + self.nb_zeros()-1:
+            if ncyls < 0 or ncyls > self.surface_genus() + len(self.signature()) - 1:
                 raise ValueError
 
         if not force_computation:
@@ -938,9 +803,10 @@ class AbelianStratum(Stratum):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: a = AbelianStratum(3,2,1); a
+            sage: a = Stratum([3,2,1], k=1)
+            sage: a
             H_4(3, 2, 1)
             sage: c = a.one_cylinder_diagram();c
             (0,8,3,2,1,6,5,4,7)-(0,8,7,6,5,4,3,2,1)
@@ -971,9 +837,9 @@ class AbelianStratum(Stratum):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: H22 = AbelianStratum(2,2)
+            sage: H22 = Stratum([2,2], k=1)
             sage: H22.cylinder_diagrams_number(3)
             18
             sage: H22.cylinder_diagrams_number(4)
@@ -987,7 +853,7 @@ class AbelianStratum(Stratum):
             sage: H22.cylinder_diagrams_number(4, force_computation=True)
             7
 
-            sage: H31 = AbelianStratum(3,1)
+            sage: H31 = Stratum([3,1], k=1)
             sage: for d in range(1,5):
             ....:     print("%d %d" %(H31.cylinder_diagrams_number(d, True, False),
             ....:                     H31.cylinder_diagrams_number(d, True, True)))
@@ -996,7 +862,7 @@ class AbelianStratum(Stratum):
             16 16
             4 4
 
-            sage: H211 = AbelianStratum(2,1,1)
+            sage: H211 = Stratum([2,1,1], k=1)
             sage: for d in range(1,6):
             ....:     print("%d %d" % (H211.cylinder_diagrams_number(d, True, False),
             ....:               H211.cylinder_diagrams_number(d, True, True)))
@@ -1006,7 +872,7 @@ class AbelianStratum(Stratum):
             27 27
             8 8
         """
-        if ncyls is not None and ncyls > self.genus() + self.nb_zeros() - 1:
+        if ncyls is not None and ncyls > self.surface_genus() + len(self.signature()) - 1:
             return 0
         if not force_computation:
             from surface_dynamics.databases.flat_surfaces import CylinderDiagrams
@@ -1041,9 +907,9 @@ class AbelianStratum(Stratum):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: C = AbelianStratum(2,0)
+            sage: C = Stratum([2,0], k=1)
             sage: p = C.single_cylinder_representative()
             sage: p
             0 1 2 3 4
@@ -1051,7 +917,7 @@ class AbelianStratum(Stratum):
             sage: p.stratum() == C
             True
 
-            sage: C = AbelianStratum(3,1)
+            sage: C = Stratum([3,1], k=1)
             sage: p = C.single_cylinder_representative(alphabet=Alphabet(name='lower'))
             sage: p
             a b c d e f g
@@ -1059,23 +925,24 @@ class AbelianStratum(Stratum):
             sage: p.stratum() == C
             True
 
-            sage: C = AbelianStratum(2)
+            sage: C = Stratum([2], k=1)
             sage: C.single_cylinder_representative()
             Traceback (most recent call last):
             ...
             ValueError: no 1,1-square-tiled surfaces in this stratum try again with H_2(2, 0)
-            sage: C = AbelianStratum(1,1)
+            sage: C = Stratum([1,1], k=1)
             sage: C.single_cylinder_representative()
             Traceback (most recent call last):
             ...
             ValueError: no 1,1-square-tiled surfaces in this stratum try again with H_2(1^2, 0^2)
         """
-        genus = self.genus()
-        nb_real_zeros = self.nb_zeros()-self.nb_fake_zeros()
+        genus = self.surface_genus()
+        nb_real_zeros = sum(map(bool, self.signature()), 0)
+        nb_fake_zeros = self.signature().count(0)
 
-        if genus == 2 and nb_real_zeros == 1 and self.nb_fake_zeros() < 1:
+        if genus == 2 and nb_real_zeros == 1 and nb_fake_zeros < 1:
             raise ValueError("no 1,1-square-tiled surfaces in this stratum try again with H_2(2, 0)")
-        elif genus == 2 and nb_real_zeros == 2 and self.nb_fake_zeros() < 2:
+        elif genus == 2 and nb_real_zeros == 2 and nb_fake_zeros < 2:
             raise ValueError("no 1,1-square-tiled surfaces in this stratum try again with H_2(1^2, 0^2)")
 
         return self.one_component().single_cylinder_representative(alphabet, reduced)
@@ -1089,24 +956,25 @@ class AbelianStratum(Stratum):
 
         Examples::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: C = AbelianStratum(4)
+            sage: C = Stratum([4], k=1)
             sage: O = C.single_cylinder_origami()
             sage: O
             (1,2,3,4,5)
             (1,4,3,5,2)
-            sage: O.stratum() == AbelianStratum(4)
+            sage: O.stratum() == Stratum([4], k=1)
             True
-            sage: C = AbelianStratum(2,0)
+            sage: C = Stratum([2,0], k=1)
             sage: O = C.single_cylinder_origami()
             sage: O
             (1,2,3,4)
             (1,3,2,4)
-            sage: O.stratum() == AbelianStratum(2)
+            sage: O.stratum() == Stratum([2], k=1)
             True
         """
         return self.single_cylinder_representative(reduced=False).to_origami()
+
 
 class AbelianStratumComponent(StratumComponent):
     r"""
@@ -1124,9 +992,9 @@ class AbelianStratumComponent(StratumComponent):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: c = AbelianStratum([1,1,1,1]).unique_component(); c
+            sage: c = Stratum([1,1,1,1], k=1).unique_component(); c
             H_3(1^4)^c
             sage: c.spin() is None
             True
@@ -1157,9 +1025,9 @@ class AbelianStratumComponent(StratumComponent):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: c = AbelianStratum(1,1,1,1).unique_component()
+            sage: c = Stratum([1,1,1,1], k=1).unique_component()
             sage: p = c.permutation_representative(alphabet="abcdefghi")
             sage: p
             a b c d e f g h i
@@ -1167,7 +1035,7 @@ class AbelianStratumComponent(StratumComponent):
             sage: p.stratum_component()
             H_3(1^4)^c
 
-            sage: cc = AbelianStratum(3,2,1,0).unique_component()
+            sage: cc = Stratum([3,2,1,0], k=1).unique_component()
             sage: p = cc.permutation_representative(left_degree=3); p
             0 1 2 3 4 5 6 7 8 9 10
             4 3 7 6 5 10 9 8 2 0 1
@@ -1210,9 +1078,9 @@ class AbelianStratumComponent(StratumComponent):
         """
         stratum = self.stratum()
 
-        g = stratum.genus()
-        zeros = list(stratum.zeros(fake_zeros=False))
-        n = stratum.nb_fake_zeros()
+        g = stratum.surface_genus()
+        zeros = list(m for m in stratum.signature() if m)
+        n = stratum.signature().count(0)
 
         if left_degree is not None and left_degree != 0:
             i = zeros.index(left_degree)
@@ -1262,12 +1130,12 @@ class AbelianStratumComponent(StratumComponent):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: AbelianStratum(2).unique_component().lyapunov_exponents_approx(nb_iterations=2**21)  # abs tol .05
+            sage: Stratum([2], k=1).unique_component().lyapunov_exponents_approx(nb_iterations=2**21)  # abs tol .05
             [1.000, 0.333]
 
-            sage: H4hyp, H4odd = AbelianStratum(4).components()
+            sage: H4hyp, H4odd = Stratum([4], k=1).components()
             sage: H4hyp.lyapunov_exponents_approx(nb_iterations=2**21) # abs tol .05
             [1.000, 0.616, 0.184]
             sage: H4odd.lyapunov_exponents_approx(nb_iterations=2**21) # abs tol .05
@@ -1303,16 +1171,16 @@ class AbelianStratumComponent(StratumComponent):
 
         EXAMPLES:
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: C = AbelianStratum(10).hyperelliptic_component()
+            sage: C = Stratum([10], k=1).hyperelliptic_component()
             sage: p = C.random_standard_permutation(); p   # random
             0 1 2 3 4 5 6 7 8 9 10 11
             11 10 9 8 7 6 5 4 3 2 1 0
             sage: p.stratum_component()
             H_6(10)^hyp
 
-            sage: C = AbelianStratum(6,4,2).odd_component(); C
+            sage: C = Stratum([6,4,2], k=1).odd_component(); C
             H_7(6, 4, 2)^odd
             sage: p = C.random_standard_permutation(); p  # random
             0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15
@@ -1320,7 +1188,7 @@ class AbelianStratumComponent(StratumComponent):
             sage: p.stratum_component()
             H_7(6, 4, 2)^odd
 
-            sage: C = AbelianStratum(2,2,2,2).even_component(); C
+            sage: C = Stratum([2,2,2,2], k=1).even_component(); C
             H_5(2^4)^even
             sage: p = C.random_standard_permutation(); p  # random
             0 1 2 3 4 5 6 7 8 9 10 11 12
@@ -1328,7 +1196,7 @@ class AbelianStratumComponent(StratumComponent):
             sage: p.stratum_component()
             H_5(2^4)^even
 
-            sage: C = AbelianStratum(32).odd_component(); C
+            sage: C = Stratum([32], k=1).odd_component(); C
             H_17(32)^odd
             sage: p = C.random_standard_permutation(); p  # random
             0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33
@@ -1375,9 +1243,9 @@ class AbelianStratumComponent(StratumComponent):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: c = AbelianStratum(0).components()[0]
+            sage: c = Stratum([0], k=1).components()[0]
             sage: r = c.rauzy_diagram()
         """
         if kwds.get("left_degree",None) is not None:
@@ -1407,14 +1275,15 @@ class AbelianStratumComponent(StratumComponent):
 
             sage: from surface_dynamics import *
 
-            sage: a = AbelianStratum({1:4}).unique_component(); a
+            sage: a = Stratum({1:4}, k=1).unique_component()
+            sage: a
             H_3(1^4)^c
             sage: a.rauzy_diagram()
             Rauzy diagram with 1255 permutations
             sage: a.rauzy_class_cardinality()
             1255
 
-            sage: cc = AbelianStratum(3,2,1).unique_component()
+            sage: cc = Stratum([3,2,1], k=1).unique_component()
             sage: cc.rauzy_diagram(left_degree=3)   # long time
             Rauzy diagram with 96434 permutations
             sage: cc.rauzy_class_cardinality(left_degree=3)
@@ -1430,43 +1299,44 @@ class AbelianStratumComponent(StratumComponent):
             sage: cc.rauzy_class_cardinality(left_degree=1)
             48954
 
-            sage: a = AbelianStratum({1:8}).unique_component(); a
+            sage: a = Stratum({1:8}, k=1).unique_component()
+            sage: a
             H_5(1^8)^c
             sage: a.rauzy_class_cardinality()
             55184875
 
         Cardinalities for labeled Rauzy classes instead of reduced::
 
-            sage: cc=AbelianStratum(2,1,1).unique_component()
-            sage: cc.rauzy_diagram(left_degree=2,reduced=False)
+            sage: cc = Stratum([2,1,1], k=1).unique_component()
+            sage: cc.rauzy_diagram(left_degree=2, reduced=False)
             Rauzy diagram with 3676 permutations
-            sage: cc.rauzy_class_cardinality(left_degree=2,reduced=False)
+            sage: cc.rauzy_class_cardinality(left_degree=2, reduced=False)
             3676
 
-            sage: cc.rauzy_diagram(left_degree=1,reduced=False)
+            sage: cc.rauzy_diagram(left_degree=1, reduced=False)
             Rauzy diagram with 3774 permutations
             sage: cc.rauzy_class_cardinality(left_degree=1,reduced=False)
             3774
 
-            sage: cc=AbelianStratum(2,1,1,0).unique_component()
-            sage: cc.rauzy_diagram(left_degree=2,reduced=False) # long time
+            sage: cc = Stratum([2,1,1,0], k=1).unique_component()
+            sage: cc.rauzy_diagram(left_degree=2, reduced=False) # long time
             Rauzy diagram with 33084 permutations
-            sage: cc.rauzy_diagram(left_degree=1,reduced=False) # long time
+            sage: cc.rauzy_diagram(left_degree=1, reduced=False) # long time
             Rauzy diagram with 33966 permutations
-            sage: cc.rauzy_diagram(left_degree=0,reduced=False) # long time
+            sage: cc.rauzy_diagram(left_degree=0, reduced=False) # long time
             Rauzy diagram with 30828 permutations
 
-            sage: cc.rauzy_class_cardinality(left_degree=2,reduced=False)
+            sage: cc.rauzy_class_cardinality(left_degree=2, reduced=False)
             33084
-            sage: cc.rauzy_class_cardinality(left_degree=1,reduced=False)
+            sage: cc.rauzy_class_cardinality(left_degree=1, reduced=False)
             33966
-            sage: cc.rauzy_class_cardinality(left_degree=0,reduced=False)
+            sage: cc.rauzy_class_cardinality(left_degree=0, reduced=False)
             30828
         """
         import surface_dynamics.interval_exchanges.rauzy_class_cardinality as rdc
 
-        profile = list(map(lambda x: x+1, self.stratum().zeros()))
-        s = self.stratum().nb_zeros()
+        profile = list(map(lambda x: x+1, self.stratum().signature()))
+        s = len(self.stratum().signature())
 
         if left_degree is not None:
             assert isinstance(left_degree, (int,Integer)), "if not None, left_degree should be an integer"
@@ -1491,9 +1361,9 @@ class AbelianStratumComponent(StratumComponent):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: cc = AbelianStratum(3,1).unique_component()
+            sage: cc = Stratum([3,1], k=1).unique_component()
             sage: sum(1 for p in cc.rauzy_diagram() if p.is_standard())
             24
             sage: cc.standard_permutations_number()
@@ -1509,14 +1379,15 @@ class AbelianStratumComponent(StratumComponent):
             sage: cc.standard_permutations_number(left_degree=1)
             8
 
-            sage: cc = AbelianStratum({1:10}).unique_component(); cc
+            sage: cc = Stratum({1:10}, k=1).unique_component()
+            sage: cc
             H_6(1^10)^c
             sage: cc.standard_permutations_number()
             59520825
         """
         import surface_dynamics.interval_exchanges.rauzy_class_cardinality as rdc
 
-        profile = [x+1 for x in self.stratum().zeros()]
+        profile = [x+1 for x in self.stratum().signature()]
 
         if left_degree is not None:
             assert isinstance(left_degree, (int,Integer)), "if not None, left_degree should be an integer"
@@ -1532,9 +1403,9 @@ class AbelianStratumComponent(StratumComponent):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: C = AbelianStratum(4).odd_component()
+            sage: C = Stratum([4], k=1).odd_component()
             sage: C
             H_3(4)^odd
             sage: for p in C.standard_permutations(): print("%s\n***********" % p)
@@ -1572,16 +1443,18 @@ class AbelianStratumComponent(StratumComponent):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: A = AbelianStratum(2,2).odd_component()
-            sage: c = A.one_cylinder_diagram(); c
+            sage: A = Stratum([2,2], k=1).odd_component()
+            sage: c = A.one_cylinder_diagram()
+            sage: c
             (0,5,1,3,2,4)-(0,5,4,3,2,1)
             sage: c.stratum_component()
             H_3(2^2)^odd
 
-            sage: A = AbelianStratum(3,3).non_hyperelliptic_component()
-            sage: c = A.one_cylinder_diagram(); c
+            sage: A = Stratum([3,3], k=1).non_hyperelliptic_component()
+            sage: c = A.one_cylinder_diagram()
+            sage: c
             (0,7,3,2,1,5,4,6)-(0,7,6,5,4,3,2,1)
             sage: c.stratum_component()
             H_4(3^2)^nonhyp
@@ -1606,9 +1479,9 @@ class AbelianStratumComponent(StratumComponent):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: A = AbelianStratum(1,1,1,1)
+            sage: A = Stratum([1,1,1,1], k=1)
             sage: cc = A.unique_component()
             sage: it = cc.cylinder_diagram_iterator(3)
             sage: cyl = next(it); cyl
@@ -1622,11 +1495,12 @@ class AbelianStratumComponent(StratumComponent):
         iteration might be different and you might obtain cylinder diagram with some
         symmetries applied::
 
-            sage: C1 = list(cc.cylinder_diagram_iterator(3, force_computation=False))  # long time
-            sage: C2 = list(cc.cylinder_diagram_iterator(3, force_computation=True))   # long time
-            sage: assert len(C1) == len(C2)                                            # long time
-            sage: isoms = []                                                           # long time
-            sage: for c in C1:                                                         # long time
+            sage: # long time
+            sage: C1 = list(cc.cylinder_diagram_iterator(3, force_computation=False))
+            sage: C2 = list(cc.cylinder_diagram_iterator(3, force_computation=True))
+            sage: assert len(C1) == len(C2)
+            sage: isoms = []
+            sage: for c in C1:
             ....:     isom = []
             ....:     for i,cc in enumerate(C2):
             ....:         if c.is_isomorphic(cc) or \
@@ -1636,12 +1510,12 @@ class AbelianStratumComponent(StratumComponent):
             ....:              isom.append(i)
             ....:     assert len(isom) == 1, isom
             ....:     isoms.extend(isom)
-            sage: assert sorted(isoms) == list(range(len(C1)))                         # long time
+            sage: assert sorted(isoms) == list(range(len(C1)))
         """
         if ncyls is not None:
             if not isinstance(ncyls, (int,Integer)):
                 raise TypeError("ncyls should be None or an integer")
-            if ncyls < 0 or ncyls > self.stratum().genus() + self.stratum().nb_zeros()-1:
+            if ncyls < 0 or ncyls > self.stratum().surface_genus() + len(self.stratum().signature()) - 1:
                 raise ValueError("ncyls is not valid")
 
         if not force_computation:
@@ -1683,9 +1557,9 @@ class AbelianStratumComponent(StratumComponent):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: C = AbelianStratum(1,1,1,1).unique_component(); C
+            sage: C = Stratum([1,1,1,1], k=1).unique_component(); C
             H_3(1^4)^c
             sage: for c in C.cylinder_diagrams(6): print(c)
             (0,1)-(7) (2)-(0) (3)-(4) (4,7)-(5,6) (5)-(1) (6)-(2,3)
@@ -1712,9 +1586,9 @@ class AbelianStratumComponent(StratumComponent):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: C = AbelianStratum(3,1).unique_component()
+            sage: C = Stratum([3,1], k=1).unique_component()
             sage: C.cylinder_diagrams_number(1)
             2
             sage: C.cylinder_diagrams_number(2)
@@ -1734,7 +1608,7 @@ class AbelianStratumComponent(StratumComponent):
             16
             4
 
-            sage: C = AbelianStratum(6)
+            sage: C = Stratum([6], k=1)
             sage: C_hyp = C.hyperelliptic_component()
             sage: C_odd = C.odd_component()
             sage: C_even = C.even_component()
@@ -1767,7 +1641,7 @@ class AbelianStratumComponent(StratumComponent):
             42
             21
         """
-        if ncyls is not None and ncyls > self.stratum().genus() + self.stratum().nb_zeros() - 1:
+        if ncyls is not None and ncyls > self.stratum().surface_genus() + len(self.stratum().signature()) - 1:
             return 0
 
         if not force_computation:
@@ -1794,13 +1668,13 @@ class AbelianStratumComponent(StratumComponent):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: a = AbelianStratum(2,2).one_component()
+            sage: a = Stratum([2,2], k=1).one_component()
             sage: a.one_origami().stratum()
             H_3(2^2)
 
-            sage: AbelianStratum(3,2,1).unique_component().one_origami().stratum()
+            sage: Stratum([3,2,1], k=1).unique_component().one_origami().stratum()
             H_4(3, 2, 1)
         """
         from surface_dynamics.flat_surfaces.origamis.origami_dense import Origami_dense_pyx
@@ -1827,9 +1701,9 @@ class AbelianStratumComponent(StratumComponent):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: cc = AbelianStratum(6).even_component()
+            sage: cc = Stratum([6], k=1).even_component()
             sage: it = cc.origami_iterator(13)
             sage: o = next(it)
             sage: o
@@ -1879,9 +1753,9 @@ class AbelianStratumComponent(StratumComponent):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: H11_hyp = AbelianStratum(1,1).hyperelliptic_component()
+            sage: H11_hyp = Stratum([1,1], k=1).hyperelliptic_component()
             sage: len(H11_hyp.origamis(6))
             88
 
@@ -1891,7 +1765,7 @@ class AbelianStratumComponent(StratumComponent):
             sage: sum(t.veech_group().index() for t in T6)
             88
 
-            sage: H4_odd = AbelianStratum(4).odd_component()
+            sage: H4_odd = Stratum([4], k=1).odd_component()
             sage: len(H4_odd.origamis(6))
             155
             sage: T6 = H4_odd.arithmetic_teichmueller_curves(6)
@@ -1906,9 +1780,9 @@ class AbelianStratumComponent(StratumComponent):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: A = AbelianStratum(2).hyperelliptic_component(); A
+            sage: A = Stratum([2], k=1).hyperelliptic_component(); A
             H_2(2)^hyp
             sage: for i in range(3,10):
             ....:     print("%d %d" % (i,len(A.arithmetic_teichmueller_curves(i))))
@@ -1920,7 +1794,7 @@ class AbelianStratumComponent(StratumComponent):
             8 1
             9 2
 
-            sage: A = AbelianStratum(1,1).hyperelliptic_component(); A
+            sage: A = Stratum([1,1], k=1).hyperelliptic_component(); A
             H_2(1^2)^hyp
             sage: for i in range(4,10):
             ....:    T = A.arithmetic_teichmueller_curves(i)
@@ -1933,7 +1807,7 @@ class AbelianStratumComponent(StratumComponent):
             8 4 2
             9 4 2
 
-            sage: A = AbelianStratum(4).hyperelliptic_component(); A
+            sage: A = Stratum([4], k=1).hyperelliptic_component(); A
             H_3(4)^hyp
             sage: for i in range(5,10):
             ....:    print("%d %d" % (i,len(A.arithmetic_teichmueller_curves(i))))
@@ -1973,9 +1847,9 @@ class AbelianStratumComponent(StratumComponent):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: cc = AbelianStratum(1,1,1,1).unique_component()
+            sage: cc = Stratum([1,1,1,1], k=1).unique_component()
             sage: p = cc.single_cylinder_representative()
             sage: p
             0 1 2 3 4 5 6 7 8
@@ -1983,7 +1857,7 @@ class AbelianStratumComponent(StratumComponent):
             sage: p.stratum_component() == cc
             True
 
-            sage: cc = AbelianStratum(2,1,1).unique_component()
+            sage: cc = Stratum([2,1,1], k=1).unique_component()
             sage: p = cc.single_cylinder_representative()
             sage: p
             0 1 2 3 4 5 6 7
@@ -1991,7 +1865,7 @@ class AbelianStratumComponent(StratumComponent):
             sage: p.stratum_component() == cc
             True
 
-            sage: cc = AbelianStratum(3,3).non_hyperelliptic_component()
+            sage: cc = Stratum([3,3], k=1).non_hyperelliptic_component()
             sage: p = cc.single_cylinder_representative(alphabet=Alphabet(name='lower'))
             sage: p
             a b c d e f g h i
@@ -2003,15 +1877,16 @@ class AbelianStratumComponent(StratumComponent):
                 only_even_2, only_odds_11, odd_zeros_one_one)
         from surface_dynamics.interval_exchanges.constructors import GeneralizedPermutation
 
-        zeros = self.stratum().zeros()
+        zeros = self.stratum().signature()
         real_zeros = [z for z in zeros if z != 0]
-        odd_zeros = [z for z in real_zeros if z%2 == 1]
-        even_zeros = [z for z in real_zeros if z%2 == 0]
+        nb_fake_zeros = len(zeros) - len(real_zeros)
+        odd_zeros = [z for z in real_zeros if z % 2 == 1]
+        even_zeros = [z for z in real_zeros if z % 2 == 0]
 
         fk_zeros_perm = GeneralizedPermutation([0],[0])
         mk_pt_perm = GeneralizedPermutation([0,1],[1,0])
-        for i in range(self.stratum().nb_fake_zeros()):
-            fk_zeros_perm = cylinder_concatenation(fk_zeros_perm,mk_pt_perm)
+        for i in range(nb_fake_zeros):
+            fk_zeros_perm = cylinder_concatenation(fk_zeros_perm, mk_pt_perm)
 
         if even_zeros == [2]:
             perm = only_even_2(odd_zeros)
@@ -2019,7 +1894,7 @@ class AbelianStratumComponent(StratumComponent):
             perm = only_odds_11(even_zeros)
         else:
             if even_zeros:
-                even_perm = AbelianStratum(even_zeros).odd_component().single_cylinder_representative()
+                even_perm = Stratum(even_zeros, k=1).odd_component().single_cylinder_representative()
             else:
                 even_perm = GeneralizedPermutation([0],[0])
             odd_perm = odd_zeros_one_one(odd_zeros)
@@ -2044,23 +1919,23 @@ class AbelianStratumComponent(StratumComponent):
 
         Examples::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: cc = AbelianStratum(4).odd_component()
+            sage: cc = Stratum([4], k=1).odd_component()
             sage: O = cc.single_cylinder_origami()
             sage: O
             (1,2,3,4,5)
             (1,4,3,5,2)
             sage: O.stratum_component() == cc
             True
-            sage: cc = AbelianStratum(5,3).unique_component()
+            sage: cc = Stratum([5,3], k=1).unique_component()
             sage: O = cc.single_cylinder_origami()
             sage: O
             (1,2,3,4,5,6,7,8,9,10)
             (1,9,8,10,6,7,4,3,5,2)
             sage: O.stratum_component() == cc
             True
-            sage: cc = AbelianStratum(4,2).even_component()
+            sage: cc = Stratum([4,2], k=1).even_component()
             sage: O = cc.single_cylinder_origami()
             sage: O
             (1,2,3,4,5,6,7,8)
@@ -2084,25 +1959,25 @@ class HypAbelianStratumComponent(ASC):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
         For the strata `H(2g-2)`::
 
-            sage: c = AbelianStratum(0).hyperelliptic_component()
+            sage: c = Stratum([0], k=1).hyperelliptic_component()
             sage: c.spin()
             1
             sage: p = c.permutation_representative()
             sage: p.arf_invariant()
             1
 
-            sage: c = AbelianStratum(2).hyperelliptic_component()
+            sage: c = Stratum([2], k=1).hyperelliptic_component()
             sage: c.spin()
             1
             sage: p = c.permutation_representative()
             sage: p.arf_invariant()
             1
 
-            sage: c = AbelianStratum(4).hyperelliptic_component()
+            sage: c = Stratum([4], k=1).hyperelliptic_component()
             sage: c.spin()
             0
             sage: p = c.permutation_representative()
@@ -2111,29 +1986,29 @@ class HypAbelianStratumComponent(ASC):
 
         For the strata `H(g-1,g-1)`::
 
-            sage: c = AbelianStratum(2,2).hyperelliptic_component()
+            sage: c = Stratum([2,2], k=1).hyperelliptic_component()
             sage: c.spin()
             0
             sage: p = c.permutation_representative()
             sage: p.arf_invariant()
             0
 
-            sage: c = AbelianStratum(4,4).hyperelliptic_component()
+            sage: c = Stratum([4,4], k=1).hyperelliptic_component()
             sage: c.spin()
             1
             sage: p = c.permutation_representative()
             sage: p.arf_invariant()
             1
         """
-        z = self.stratum().zeros(fake_zeros=False)
+        z = tuple(m for m in self.stratum().signature() if m > 0)
         if not z:
             return Integer(1)
         elif len(z) == 1:
-            return Integer(((self.stratum().genus()+1)//2) % 2)
+            return Integer(((self.stratum().surface_genus()+1)//2) % 2)
         elif len(z) == 2:
             if z[0] % 2:
                 return None
-            return Integer(((self.stratum().genus()+1)//2) %2)
+            return Integer(((self.stratum().surface_genus()+1)//2) %2)
 
     def permutation_representative(self, left_degree=None, reduced=True, alphabet=None, relabel=True):
         r"""
@@ -2153,9 +2028,9 @@ class HypAbelianStratumComponent(ASC):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: c = AbelianStratum(0).hyperelliptic_component()
+            sage: c = Stratum([0], k=1).hyperelliptic_component()
             sage: p = c.permutation_representative()
             sage: p
             0 1
@@ -2163,7 +2038,7 @@ class HypAbelianStratumComponent(ASC):
             sage: p.stratum_component()
             H_1(0)^hyp
 
-            sage: c = AbelianStratum(0,0).hyperelliptic_component()
+            sage: c = Stratum([0,0], k=1).hyperelliptic_component()
             sage: p = c.permutation_representative(alphabet="abc")
             sage: p
             a b c
@@ -2171,12 +2046,12 @@ class HypAbelianStratumComponent(ASC):
             sage: p.stratum_component()
             H_1(0^2)^hyp
 
-            sage: c = AbelianStratum(2,2).hyperelliptic_component()
+            sage: c = Stratum([2,2], k=1).hyperelliptic_component()
             sage: p = c.permutation_representative(alphabet="ABCDEFGHIJKL")
             sage: p
             A B C D E F G
             G F E D C B A
-            sage: c = AbelianStratum(1,1,0).hyperelliptic_component()
+            sage: c = Stratum([1,1,0], k=1).hyperelliptic_component()
             sage: p = c.permutation_representative(left_degree=1); p
             0 1 2 3 4 5
             5 1 4 3 2 0
@@ -2193,12 +2068,12 @@ class HypAbelianStratumComponent(ASC):
             sage: p.rauzy_diagram()
             Rauzy diagram with 20 permutations
         """
-        g = self._stratum.genus()
+        g = self._stratum.surface_genus()
         n = self._stratum.nb_fake_zeros()
-        m = len(self._stratum.zeros(fake_zeros=False))
+        m = sum(x != 0 for x in self._stratum.signature())
 
         if left_degree is not None:
-            if not isinstance(left_degree, (int,Integer)) or left_degree not in self.stratum().zeros():
+            if not isinstance(left_degree, (int,Integer)) or left_degree not in self.stratum().signature():
                 raise ValueError("left_degree (=%d) should be one of the degree"%left_degree)
 
         if m == 0:  # on the torus
@@ -2274,16 +2149,16 @@ class HypAbelianStratumComponent(ASC):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
         The case of the torus is a little bit different::
 
-            sage: c = AbelianStratum(0).hyperelliptic_component()
+            sage: c = Stratum([0], k=1).hyperelliptic_component()
             sage: c.rauzy_diagram()
             Rauzy diagram with 1 permutation
             sage: c.rauzy_class_cardinality()
             1
-            sage: c = AbelianStratum(0,0).hyperelliptic_component()
+            sage: c = Stratum([0,0], k=1).hyperelliptic_component()
             sage: c.rauzy_diagram()
             Rauzy diagram with 3 permutations
             sage: c.rauzy_class_cardinality()
@@ -2291,7 +2166,7 @@ class HypAbelianStratumComponent(ASC):
 
         Examples in genus 2::
 
-            sage: c = AbelianStratum(2,0).hyperelliptic_component()
+            sage: c = Stratum([2,0], k=1).hyperelliptic_component()
             sage: c.rauzy_diagram()
             Rauzy diagram with 46 permutations
             sage: c.rauzy_class_cardinality()
@@ -2311,7 +2186,7 @@ class HypAbelianStratumComponent(ASC):
             sage: c.rauzy_class_cardinality(left_degree=0, reduced=False)
             33
 
-            sage: c = AbelianStratum(1,1,0,0).hyperelliptic_component()
+            sage: c = Stratum([1,1,0,0], k=1).hyperelliptic_component()
             sage: c.rauzy_diagram()
             Rauzy diagram with 455 permutations
             sage: c.rauzy_class_cardinality()
@@ -2337,13 +2212,13 @@ class HypAbelianStratumComponent(ASC):
 
         Other examples in higher genus::
 
-            sage: c = AbelianStratum(12,0,0).hyperelliptic_component()
+            sage: c = Stratum([12,0,0], k=1).hyperelliptic_component()
             sage: c.rauzy_class_cardinality()
             1114200
             sage: c.rauzy_class_cardinality(left_degree=12, reduced=False)
             1965840
 
-            sage: c = AbelianStratum(14).hyperelliptic_component()
+            sage: c = Stratum([14], k=1).hyperelliptic_component()
             sage: c.rauzy_class_cardinality()
             32767
         """
@@ -2351,17 +2226,17 @@ class HypAbelianStratumComponent(ASC):
 
         if left_degree is not None:
             assert isinstance(left_degree, (int,Integer)), "if not None, left_degree should be an integer"
-            assert left_degree in self.stratum().zeros(), "if not None, the degree should be one of the degree of the stratum"
+            assert left_degree in self.stratum().signature(), "if not None, the degree should be one of the degree of the stratum"
 
         if reduced is False:
             if left_degree is None:
                 raise NotImplementedError("no formula known for cardinality of labeled extended Rauzy classes")
-            zeros = self.stratum().zeros()
+            zeros = self.stratum().signature()
             profile = Partition([x+1 for x in zeros])
-            if self.stratum().nb_zeros(fake_zeros=False) == 1:
+            if sum(bool(z) for z in self.stratum().signature()) == 1:
                 epsilon = 1
             else:
-                epsilon = Rational((1,self.stratum().genus()))
+                epsilon = Rational((1,self.stratum().surface_genus()))
             return epsilon * (profile.centralizer_size() /
                     ((left_degree+1) * zeros.count(left_degree)) *
                     self.rauzy_class_cardinality(left_degree=left_degree,reduced=True))
@@ -2370,7 +2245,7 @@ class HypAbelianStratumComponent(ASC):
         dd = self.stratum().dimension()  # it is d+k
         d = dd-k
 
-        if self.stratum().genus() == 1:
+        if self.stratum().surface_genus() == 1:
             if k == 0: return 1
             return binomial(dd,2)
 
@@ -2397,9 +2272,9 @@ class HypAbelianStratumComponent(ASC):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: AbelianStratum(6).hyperelliptic_component().standard_permutations()
+            sage: Stratum([6], k=1).hyperelliptic_component().standard_permutations()
             [0 1 2 3 4 5 6 7
              7 6 5 4 3 2 1 0]
         """
@@ -2440,16 +2315,16 @@ class HypAbelianStratumComponent(ASC):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum, CylinderDiagram
 
-            sage: C = AbelianStratum(2,2).hyperelliptic_component()
+            sage: C = Stratum([2,2], k=1).hyperelliptic_component()
             sage: [sum(1 for c in C.cylinder_diagram_iterator(n)) for n in range(1,5)]
             [1, 3, 5, 2]
 
         When ``ncyls`` is set to ``None``, the iterator can reasonably be used
         with very large data::
 
-            sage: C = AbelianStratum(10,10).hyperelliptic_component()
+            sage: C = Stratum([10,10], k=1).hyperelliptic_component()
             sage: it = C.cylinder_diagram_iterator()
             sage: c = next(it)
             sage: c.is_isomorphic(CylinderDiagram('(0,2,5,1)-(0,2,21,1) (3,4)-(3,6) (6,19)-(4,20) (7,9)-(8,10) (8,12)-(7,11) (10,14)-(9,13) (11,15)-(12,16) (13,17)-(14,18) (16,20)-(15,19) (18,21)-(5,17)'))
@@ -2470,7 +2345,7 @@ class HypAbelianStratumComponent(ASC):
         if stratum.nb_fake_zeros():
             raise ValueError("the stratum has fake zeros")
 
-        z = stratum.zeros()
+        z = stratum.signature()
 
         return hyperelliptic_cylinder_diagram_iterator(len(z)+sum(z))
 
@@ -2493,9 +2368,9 @@ class HypAbelianStratumComponent(ASC):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: cc = AbelianStratum(2,0).hyperelliptic_component()
+            sage: cc = Stratum([2,0], k=1).hyperelliptic_component()
             sage: p = cc.single_cylinder_representative(alphabet=Alphabet(name='upper'))
             sage: p
             A B C D E
@@ -2503,7 +2378,7 @@ class HypAbelianStratumComponent(ASC):
             sage: p.stratum_component() == cc
             True
 
-            sage: cc = AbelianStratum({3:2,0:6}).hyperelliptic_component()
+            sage: cc = Stratum({3:2,0:6}, k=1).hyperelliptic_component()
             sage: p = cc.single_cylinder_representative()
             sage: p
             0 1 2 3 4 5 6 7 8 9 10 11 12 13 14
@@ -2511,29 +2386,29 @@ class HypAbelianStratumComponent(ASC):
             sage: p.stratum_component() == cc
             True
 
-            sage: cc = AbelianStratum(2).hyperelliptic_component()
+            sage: cc = Stratum([2], k=1).hyperelliptic_component()
             sage: cc.single_cylinder_representative()
             Traceback (most recent call last):
             ...
             ValueError: no 1,1-square-tiled surfaces in this connected component try again with H_2(2, 0)^hyp
-            sage: cc = AbelianStratum({3:2,0:5}).hyperelliptic_component()
+            sage: cc = Stratum({3:2,0:5}, k=1).hyperelliptic_component()
             sage: cc.single_cylinder_representative()
             Traceback (most recent call last):
             ...
             ValueError: no 1,1-square-tiled surfaces in this connected component try again with H_4(3^2, 0^6)^hyp
         """
         stratum = self.stratum()
-        genus = stratum.genus()
-        nb_fk_zeros = stratum.nb_fake_zeros()
-        nb_real_zeros = stratum.nb_zeros()-nb_fk_zeros
-        add_fk_zeros = nb_fk_zeros - 2*genus+4-nb_real_zeros
+        genus = stratum.surface_genus()
+        nb_fk_zeros = sum(m == 0 for m in stratum.signature())
+        nb_real_zeros = sum(m != 0 for m in stratum.signature())
+        add_fk_zeros = nb_fk_zeros - 2 * genus + 4 - nb_real_zeros
 
         from surface_dynamics.interval_exchanges.constructors import GeneralizedPermutation
 
         if nb_real_zeros == 1 and add_fk_zeros < 0:
-            raise ValueError("no 1,1-square-tiled surfaces in this connected component try again with %s^hyp" %(str(AbelianStratum({2*genus-2:1,0:2*genus-3}))))
+            raise ValueError("no 1,1-square-tiled surfaces in this connected component try again with %s^hyp" %(str(Stratum({2*genus-2:1,0:2*genus-3}, k=1))))
         elif nb_real_zeros == 2 and add_fk_zeros < 0:
-            raise ValueError("no 1,1-square-tiled surfaces in this connected component try again with %s^hyp" %(str(AbelianStratum({genus-1:2,0:2*genus-2}))))
+            raise ValueError("no 1,1-square-tiled surfaces in this connected component try again with %s^hyp" %(str(Stratum({genus-1:2,0:2*genus-2}, k=1))))
         elif not nb_real_zeros:
             from surface_dynamics.flat_surfaces.single_cylinder import cylinder_concatenation
             fk_zeros_perm = GeneralizedPermutation([0],[0])
@@ -2584,15 +2459,15 @@ class NonHypAbelianStratumComponent(ASC):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
         Examples in genus 3::
 
-            sage: c = AbelianStratum(3,3).non_hyperelliptic_component()
+            sage: c = Stratum([3,3], k=1).non_hyperelliptic_component()
             sage: c.rauzy_class_cardinality()
             15568
 
-            sage: c = AbelianStratum(3,3,0).non_hyperelliptic_component()
+            sage: c = Stratum([3,3,0], k=1).non_hyperelliptic_component()
             sage: c.rauzy_class_cardinality()
             173723
 
@@ -2616,11 +2491,11 @@ class NonHypAbelianStratumComponent(ASC):
 
         When genus growths, the size of the Rauzy diagram becomes very big::
 
-            sage: c = AbelianStratum(5,5).non_hyperelliptic_component()
+            sage: c = Stratum([5,5], k=1).non_hyperelliptic_component()
             sage: c.rauzy_class_cardinality()
             136116680
 
-            sage: c = AbelianStratum(7,7,0).non_hyperelliptic_component()
+            sage: c = Stratum([7,7,0], k=1).non_hyperelliptic_component()
             sage: c.rauzy_class_cardinality()
             88484743236111
             sage: c.rauzy_class_cardinality(left_degree=7, reduced=False)
@@ -2628,7 +2503,7 @@ class NonHypAbelianStratumComponent(ASC):
         """
         import surface_dynamics.interval_exchanges.rauzy_class_cardinality as rdc
 
-        profile = list(map(lambda x: x+1,self.stratum().zeros()))
+        profile = list(map(lambda x: x+1,self.stratum().signature()))
         hyp = self.stratum().hyperelliptic_component()
 
         if left_degree is not None:
@@ -2658,25 +2533,25 @@ class NonHypAbelianStratumComponent(ASC):
         r"""
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: C = AbelianStratum(3,3).non_hyperelliptic_component()
+            sage: C = Stratum([3,3], k=1).non_hyperelliptic_component()
             sage: len(C.standard_permutations())  # long time
             275
             sage: C.standard_permutations_number()
             275
 
-            sage: C = AbelianStratum(5,5).non_hyperelliptic_component()
+            sage: C = Stratum([5,5], k=1).non_hyperelliptic_component()
             sage: C.standard_permutations_number()
             1022399
 
-            sage: C = AbelianStratum(7,7).non_hyperelliptic_component()
+            sage: C = Stratum([7,7], k=1).non_hyperelliptic_component()
             sage: C.standard_permutations_number()
             19229011199
         """
         import surface_dynamics.interval_exchanges.rauzy_class_cardinality as rdc
 
-        profile = list(map(lambda x: x+1, self.stratum().zeros()))
+        profile = list(map(lambda x: x+1, self.stratum().signature()))
         return rdc.number_of_standard_permutations(profile) - self.stratum().hyperelliptic_component().standard_permutations_number()
 
     def _cylinder_diagram_iterator(self, ncyls=None):
@@ -2686,9 +2561,9 @@ class NonHypAbelianStratumComponent(ASC):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: cc = AbelianStratum(3,3).non_hyperelliptic_component()
+            sage: cc = Stratum([3,3], k=1).non_hyperelliptic_component()
             sage: it = cc.cylinder_diagram_iterator()
             sage: c0 = next(it); c0
             (0,1,4,6,2,5,3,7)-(0,1,4,5,3,6,2,7)
@@ -2728,9 +2603,9 @@ class EvenAbelianStratumComponent(ASC):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: c = AbelianStratum(4,2).even_component(); c
+            sage: c = Stratum([4,2], k=1).even_component(); c
             H_4(4, 2)^even
             sage: c.spin()
             0
@@ -2760,9 +2635,9 @@ class EvenAbelianStratumComponent(ASC):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: c = AbelianStratum(6).even_component()
+            sage: c = Stratum([6], k=1).even_component()
             sage: c
             H_4(6)^even
             sage: p = c.permutation_representative(alphabet=range(8))
@@ -2774,7 +2649,7 @@ class EvenAbelianStratumComponent(ASC):
 
         ::
 
-            sage: c = AbelianStratum(4,4).even_component()
+            sage: c = Stratum([4,4], k=1).even_component()
             sage: c
             H_5(4^2)^even
             sage: p = c.permutation_representative(alphabet=range(11))
@@ -2786,7 +2661,7 @@ class EvenAbelianStratumComponent(ASC):
 
         Different markings lead to different Rauzy diagrams::
 
-            sage: c = AbelianStratum(4,2,0).even_component()
+            sage: c = Stratum([4,2,0], k=1).even_component()
             sage: p = c.permutation_representative(left_degree=4); p
             0 1 2 3 4 5 6 7 8 9
             6 5 4 3 7 9 8 2 0 1
@@ -2817,9 +2692,9 @@ class EvenAbelianStratumComponent(ASC):
             sage: p.rauzy_diagram()   # long time
             Rauzy diagram with 11792 permutations
         """
-        z = list(self._stratum.zeros(fake_zeros=False))
-        n = self._stratum.nb_fake_zeros()
-        g = self._stratum.genus()
+        z = list(m for m in self._stratum.signature() if m)
+        n = self._stratum.signature().count(0)
+        g = self._stratum.surface_genus()
 
         if left_degree is not None:
             if not isinstance(left_degree, (int,Integer)):
@@ -2841,7 +2716,7 @@ class EvenAbelianStratumComponent(ASC):
 
         k = 4
         for d in z:
-            for i in range(d/2-1):
+            for i in range(d//2 - 1):
                 del l0[l0.index(k)]
                 del l1[l1.index(k)]
                 k += 3
@@ -2886,15 +2761,15 @@ class EvenAbelianStratumComponent(ASC):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: c = AbelianStratum(6).even_component()
+            sage: c = Stratum([6], k=1).even_component()
             sage: c.rauzy_diagram()
             Rauzy diagram with 2327 permutations
             sage: c.rauzy_class_cardinality()
             2327
 
-            sage: c = AbelianStratum(4,2,0).even_component()
+            sage: c = Stratum([4,2,0], k=1).even_component()
             sage: c.rauzy_class_cardinality()
             117472
 
@@ -2927,7 +2802,7 @@ class EvenAbelianStratumComponent(ASC):
         """
         import surface_dynamics.interval_exchanges.rauzy_class_cardinality as rdc
 
-        profile = list(map(lambda x: x+1, self.stratum().zeros()))
+        profile = list(map(lambda x: x+1, self.stratum().signature()))
         if left_degree is not None:
             assert isinstance(left_degree, (int,Integer)), "if not None, left_degree should be an integer"
             left_degree = int(left_degree) + 1
@@ -2960,24 +2835,24 @@ class EvenAbelianStratumComponent(ASC):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
         For strata in genus 3, the number of standard permutations is reasonably
         small and the whole set can be computed::
 
-            sage: C = AbelianStratum(6).even_component()
+            sage: C = Stratum([6], k=1).even_component()
             sage: len(C.standard_permutations())  # long time
             44
             sage: C.standard_permutations_number()
             44
 
-            sage: C = AbelianStratum(4,2).even_component()
+            sage: C = Stratum([4,2], k=1).even_component()
             sage: len(C.standard_permutations())   # long time
             136
             sage: C.standard_permutations_number()
             136
 
-            sage: C = AbelianStratum(2,2,2).even_component()
+            sage: C = Stratum([2,2,2], k=1).even_component()
             sage: len(C.standard_permutations())   # long time
             92
             sage: C.standard_permutations_number()
@@ -2985,13 +2860,13 @@ class EvenAbelianStratumComponent(ASC):
 
         For higher genera, this number can be very big::
 
-            sage: C = AbelianStratum(20).even_component()
+            sage: C = Stratum([20], k=1).even_component()
             sage: C.standard_permutations_number()
             109398514483439999
         """
         import surface_dynamics.interval_exchanges.rauzy_class_cardinality as rdc
 
-        profile = [x+1 for x in self.stratum().zeros()]
+        profile = [x+1 for x in self.stratum().signature()]
         N = Integer(rdc.gamma_std(profile) - rdc.delta_std(profile)) / 2
 
         if (self.stratum().number_of_components() == 3 and
@@ -3006,9 +2881,9 @@ class EvenAbelianStratumComponent(ASC):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: cc = AbelianStratum(4,2).even_component()
+            sage: cc = Stratum([4,2], k=1).even_component()
             sage: it = cc.cylinder_diagram_iterator(4)
             sage: next(it).stratum_component()
             H_4(4, 2)^even
@@ -3044,9 +2919,9 @@ class EvenAbelianStratumComponent(ASC):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: cc = AbelianStratum(6).even_component()
+            sage: cc = Stratum([6], k=1).even_component()
             sage: p = cc.single_cylinder_representative(alphabet=Alphabet(name='lower'))
             sage: p
             a b c d e f g h
@@ -3054,7 +2929,7 @@ class EvenAbelianStratumComponent(ASC):
             sage: p.stratum_component() == cc
             True
 
-            sage: cc = AbelianStratum(4,4).even_component()
+            sage: cc = Stratum([4,4], k=1).even_component()
             sage: p = cc.single_cylinder_representative()
             sage: p
             0 1 2 3 4 5 6 7 8 9 10
@@ -3067,7 +2942,7 @@ class EvenAbelianStratumComponent(ASC):
                 one_two_even, two_twos_even, even_twos_even, odd_twos_even)
         from surface_dynamics.interval_exchanges.constructors import GeneralizedPermutation
 
-        zeros = self.stratum().zeros()
+        zeros = self.stratum().signature()
         real_zeros = [z for z in zeros if z != 0]
 
         fk_zeros_perm = GeneralizedPermutation([0],[0])
@@ -3106,9 +2981,9 @@ class OddAbelianStratumComponent(ASC):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: c = AbelianStratum(4).odd_component(); c
+            sage: c = Stratum([4], k=1).odd_component(); c
             H_3(4)^odd
             sage: c.spin()
             1
@@ -3124,9 +2999,9 @@ class OddAbelianStratumComponent(ASC):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: a = AbelianStratum(6).odd_component()
+            sage: a = Stratum([6], k=1).odd_component()
             sage: p = a.permutation_representative()
             sage: p
             0 1 2 3 4 5 6 7
@@ -3136,7 +3011,7 @@ class OddAbelianStratumComponent(ASC):
 
         ::
 
-            sage: a = AbelianStratum(4,4).odd_component()
+            sage: a = Stratum([4,4], k=1).odd_component()
             sage: p = a.permutation_representative()
             sage: p
             0 1 2 3 4 5 6 7 8 9 10
@@ -3146,7 +3021,7 @@ class OddAbelianStratumComponent(ASC):
 
         Different markings lead to different Rauzy diagrams::
 
-            sage: c = AbelianStratum(4,2,0).odd_component()
+            sage: c = Stratum([4,2,0], k=1).odd_component()
             sage: p = c.permutation_representative(left_degree=4); p
             0 1 2 3 4 5 6 7 8 9
             4 3 6 5 7 9 8 2 0 1
@@ -3177,9 +3052,9 @@ class OddAbelianStratumComponent(ASC):
             sage: p.rauzy_diagram()   # long time
             Rauzy diagram with 27754 permutations
         """
-        zeros = list(self.stratum().zeros(fake_zeros=False))
-        n = self._stratum.nb_fake_zeros()
-        g = self._stratum.genus()
+        zeros = list(m for m in self.stratum().signature() if m)
+        n = self.stratum().signature().count(0)
+        g = self.stratum().surface_genus()
 
         if left_degree is not None:
             if not isinstance(left_degree, (int,Integer)):
@@ -3247,28 +3122,28 @@ class OddAbelianStratumComponent(ASC):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
         The genus must be at least 3 to have an odd component::
 
-            sage: c = AbelianStratum(4).odd_component()
+            sage: c = Stratum([4], k=1).odd_component()
             sage: c.rauzy_diagram()
             Rauzy diagram with 134 permutations
             sage: c.rauzy_class_cardinality()
             134
-            sage: c = AbelianStratum(4,0).odd_component()
+            sage: c = Stratum([4,0], k=1).odd_component()
             sage: c.rauzy_diagram()
             Rauzy diagram with 1114 permutations
             sage: c.rauzy_class_cardinality()
             1114
 
-            sage: c = AbelianStratum(2,2).odd_component()
+            sage: c = Stratum([2,2], k=1).odd_component()
             sage: c.rauzy_diagram()
             Rauzy diagram with 294 permutations
             sage: c.rauzy_class_cardinality()
             294
 
-            sage: c = AbelianStratum(2,2,0).odd_component()
+            sage: c = Stratum([2,2,0], k=1).odd_component()
             sage: c.rauzy_class_cardinality()
             2723
 
@@ -3294,10 +3169,10 @@ class OddAbelianStratumComponent(ASC):
         Example in higher genus for which an explicit computation of the Rauzy
         diagram would be very long::
 
-            sage: c = AbelianStratum(4,2,0).odd_component()
+            sage: c = Stratum([4,2,0], k=1).odd_component()
             sage: c.rauzy_class_cardinality()
             262814
-            sage: c = AbelianStratum(4,4,4).odd_component()
+            sage: c = Stratum([4,4,4], k=1).odd_component()
             sage: c.rauzy_class_cardinality()
             24691288838
             sage: c.rauzy_class_cardinality(left_degree=4, reduced=False)
@@ -3305,7 +3180,7 @@ class OddAbelianStratumComponent(ASC):
         """
         import surface_dynamics.interval_exchanges.rauzy_class_cardinality as rdc
 
-        profile = list(map(lambda x: x+1, self.stratum().zeros()))
+        profile = list(map(lambda x: x+1, self.stratum().signature()))
         if left_degree is not None:
             assert isinstance(left_degree, (int,Integer)), "if not None, left_degree should be an integer"
             left_degree = int(left_degree) + 1
@@ -3334,17 +3209,17 @@ class OddAbelianStratumComponent(ASC):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
         In genus 2, there are two strata which contains an odd component::
 
-            sage: C = AbelianStratum(4).odd_component()
+            sage: C = Stratum([4], k=1).odd_component()
             sage: len(C.standard_permutations())
             7
             sage: C.standard_permutations_number()
             7
 
-            sage: C = AbelianStratum(2,2).odd_component()
+            sage: C = Stratum([2,2], k=1).odd_component()
             sage: len(C.standard_permutations())
             11
             sage: C.standard_permutations_number()
@@ -3353,19 +3228,19 @@ class OddAbelianStratumComponent(ASC):
         In genus 3, the number of standard permutations is reasonably small and
         the whole set can be computed::
 
-            sage: C = AbelianStratum(6).odd_component()
+            sage: C = Stratum([6], k=1).odd_component()
             sage: len(C.standard_permutations())   # long time
             135
             sage: C.standard_permutations_number()
             135
 
-            sage: C = AbelianStratum(4,2).odd_component()
+            sage: C = Stratum([4,2], k=1).odd_component()
             sage: len(C.standard_permutations())   # long time
             472
             sage: C.standard_permutations_number()
             472
 
-            sage: C = AbelianStratum(2,2,2).odd_component()
+            sage: C = Stratum([2,2,2], k=1).odd_component()
             sage: len(C.standard_permutations())   # long time
             372
             sage: C.standard_permutations_number()
@@ -3373,13 +3248,13 @@ class OddAbelianStratumComponent(ASC):
 
         For higher genera, this number can be very big::
 
-            sage: C = AbelianStratum(8,6,4,2).odd_component()
+            sage: C = Stratum([8,6,4,2], k=1).odd_component()
             sage: C.standard_permutations_number()
             26596699869748377600
         """
         import surface_dynamics.interval_exchanges.rauzy_class_cardinality as rdc
 
-        profile = [x+1 for x in self.stratum().zeros()]
+        profile = [x+1 for x in self.stratum().signature()]
         N = Integer(rdc.gamma_std(profile) + rdc.delta_std(profile)) / 2
 
         if (self.stratum().number_of_components() == 3 and
@@ -3395,9 +3270,9 @@ class OddAbelianStratumComponent(ASC):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: C = AbelianStratum(4).odd_component()
+            sage: C = Stratum([4], k=1).odd_component()
             sage: for c in C.cylinder_diagrams(1): print(c)
             (0,2,1,4,3)-(0,4,2,1,3)
             (0,4,1,2,3)-(0,1,3,4,2)
@@ -3439,9 +3314,9 @@ class OddAbelianStratumComponent(ASC):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: cc = AbelianStratum(4).odd_component()
+            sage: cc = Stratum([4], k=1).odd_component()
             sage: p = cc.single_cylinder_representative(alphabet=Alphabet(name='upper'))
             sage: p
             A B C D E F
@@ -3449,7 +3324,7 @@ class OddAbelianStratumComponent(ASC):
             sage: p.stratum_component() == cc
             True
 
-            sage: cc = AbelianStratum(6,2).odd_component()
+            sage: cc = Stratum([6,2], k=1).odd_component()
             sage: p = cc.single_cylinder_representative()
             sage: p
             0 1 2 3 4 5 6 7 8 9 10
@@ -3461,7 +3336,7 @@ class OddAbelianStratumComponent(ASC):
                 no_two_odd, one_two_odd, even_twos_odd, odd_twos_odd)
         from surface_dynamics.interval_exchanges.constructors import GeneralizedPermutation
 
-        zeros = self.stratum().zeros()
+        zeros = self.stratum().signature()
         real_zeros = [z for z in zeros if z != 0]
 
         fk_zeros_perm = GeneralizedPermutation([0],[0])
@@ -3665,7 +3540,7 @@ class AbelianStrata(Strata):
 
         TESTS::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum, AbelianStrata
 
             sage: a = AbelianStrata(genus=3)
             sage: all(s in a for s in a)
@@ -3678,19 +3553,19 @@ class AbelianStrata(Strata):
             sage: a = AbelianStrata(dimension=7,fake_zeros=True)
             sage: all(s in a for s in a)
             True
-            sage: AbelianStratum(2,0,0) in a
+            sage: Stratum([2,0,0], k=1) in a
             False
 
             sage: a = AbelianStrata(dimension=7,fake_zeros=False)
             sage: all(s in a for s in a)
             True
-            sage: AbelianStratum(4,0) in a
+            sage: Stratum([4,0], k=1) in a
             False
         """
         if not isinstance(c, AbelianStratum):
             return False
 
-        return ((self._genus is None or c.genus() == self._genus) and
+        return ((self._genus is None or c.surface_genus() == self._genus) and
                 (self._dimension is None or c.dimension() == self._dimension) and
                 (self._fake_zeros is None or self._fake_zeros or not c.nb_fake_zeros()))
 
@@ -3749,10 +3624,10 @@ class AbelianStrata_g(AbelianStrata):
         if self._genus == 0:
             pass
         elif self._genus == 1:
-            yield AbelianStratum([0])
+            yield Stratum([0], k=1)
         else:
             for p in Partitions(2*self._genus-2):
-                yield AbelianStratum(p._list)
+                yield Stratum(p._list, k=1)
 
     def random_element(self):
         r"""
@@ -3761,8 +3636,8 @@ class AbelianStrata_g(AbelianStrata):
         if self._genus == 0:
             raise ValueError("No stratum with that genus")
         if self._genus == 1:
-            return AbelianStratum([0])
-        return AbelianStratum(Partitions(2*self._genus - 2).random_element())
+            return Stratum([0], k=1)
+        return Stratum(Partitions(2*self._genus - 2).random_element(), k=1)
 
     def first(self):
         r"""
@@ -3770,14 +3645,14 @@ class AbelianStrata_g(AbelianStrata):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import AbelianStrata
 
             sage: AbelianStrata(genus=3).first()
             H_3(4)
             sage: AbelianStrata(genus=4).first()
             H_4(6)
         """
-        return AbelianStratum([2*self._genus-2])
+        return Stratum([2*self._genus-2], k=1)
 
     an_element_ = first
 
@@ -3794,7 +3669,7 @@ class AbelianStrata_g(AbelianStrata):
             sage: AbelianStrata(genus=5).last()
             H_5(1^8)
         """
-        return AbelianStratum({1:2*self._genus-2})
+        return Stratum({1:2*self._genus-2}, k=1)
 
 
 class AbelianStrata_d(AbelianStrata):
@@ -3830,7 +3705,7 @@ class AbelianStrata_d(AbelianStrata):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import AbelianStrata
 
             sage: AbelianStrata(dimension=2).first()
             H_1(0)
@@ -3841,8 +3716,8 @@ class AbelianStrata_d(AbelianStrata):
         """
         n = self._dimension
         if n%2:
-            return AbelianStratum([(n-3)//2,(n-3)//2])
-        return AbelianStratum([n-2])
+            return Stratum([(n-3)//2,(n-3)//2], k=1)
+        return Stratum([n-2], k=1)
 
     an_element = first
 
@@ -3852,7 +3727,7 @@ class AbelianStrata_d(AbelianStrata):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import AbelianStrata
 
             sage: AbelianStrata(dimension=9,fake_zeros=True).last()
             H_1(0^8)
@@ -3866,17 +3741,17 @@ class AbelianStrata_d(AbelianStrata):
         """
         n = self._dimension
         if self._fake_zeros:
-            return AbelianStratum({0:n-1})
+            return Stratum({0:n-1}, k=1)
         else:
             if n == 4:
-                return AbelianStratum([2])
+                return Stratum([2], k=1)
             if n == 5:
-                return AbelianStratum([1,1])
+                return Stratum([1,1], k=1)
             elif n == 6:
-                return AbelianStratum([4])
+                return Stratum([4], k=1)
             else:
                 nn = (n-2)%4
-                return AbelianStratum({2:3-nn,1:2*((n-10)//4)+2*nn})
+                return Stratum({2:3-nn,1:2*((n-10)//4)+2*nn}, k=1)
 
     def __iter__(self):
         r"""
@@ -3896,14 +3771,14 @@ class AbelianStrata_d(AbelianStrata):
         elif self._fake_zeros:
             for s in range(1+n%2, n, 2):
                 for p in Partitions(n-1, length=s):
-                    yield AbelianStratum([k-1 for k in p])
+                    yield Stratum([k-1 for k in p], k=1)
         else:
             if n == 2:
-                yield AbelianStratum([0])
+                yield Stratum([0], k=1)
             else:
                 for s in range(1+n%2, n, 2):
                     for p in Partitions(n-1,length=s,min_part=2):
-                        yield AbelianStratum([k-1 for k in p])
+                        yield Stratum([k-1 for k in p], k=1)
 
     def cardinality(self):
         r"""
@@ -3984,15 +3859,15 @@ class AbelianStrata_gd(AbelianStrata):
             pass
         elif self._genus == 1:
             if self._dimension >= 2 and self._fake_zeros:
-                yield AbelianStratum([0]*(self._dimension-1))
+                yield Stratum([0]*(self._dimension-1), k=1)
         else:
             s = self._dimension - 2*self._genus + 1
             if self._fake_zeros:
                 for p in Partitions(2*self._genus - 2 + s, length=s):
-                    yield AbelianStratum([k-1 for k in p])
+                    yield Stratum([k-1 for k in p], k=1)
             else:
                 for p in Partitions(2*self._genus - 2, length=s):
-                    yield AbelianStratum(p)
+                    yield Stratum(p, k=1)
 
 class AbelianStrata_all(AbelianStrata):
     r"""

--- a/surface_dynamics/flat_surfaces/all.py
+++ b/surface_dynamics/flat_surfaces/all.py
@@ -9,8 +9,9 @@
 
 from __future__ import absolute_import
 
-from .abelian_strata import AbelianStrata, AbelianStratum
-from .quadratic_strata import QuadraticStrata, QuadraticStratum
+from .strata import Stratum
+from .abelian_strata import AbelianStrata, DeprecatedAbelianStratumConstructor as AbelianStratum
+from .quadratic_strata import QuadraticStrata, DeprecatedQuadraticStratumConstructor as QuadraticStratum
 from .homology import RibbonGraph, RibbonGraphWithAngles
 from .separatrix_diagram import SeparatrixDiagram, CylinderDiagram, QuadraticCylinderDiagram
 from .origamis.all import *

--- a/surface_dynamics/flat_surfaces/masur_veech_volumes.py
+++ b/surface_dynamics/flat_surfaces/masur_veech_volumes.py
@@ -11,6 +11,7 @@ Masur-Veech volumes of Abelian strata and their connected components
 from sage.all import ZZ, QQ, zeta, pi
 from sage.arith.misc import bernoulli, factorial
 
+from .strata import Stratum
 from .abelian_strata import AbelianStratum, AbelianStratumComponent
 from .quadratic_strata import QuadraticStratum, QuadraticStratumComponent
 
@@ -19,48 +20,48 @@ from .quadratic_strata import QuadraticStratum, QuadraticStratumComponent
 # - Eskin-Masur-Zorich "principal boundary ..."
 abelian_volumes_table = {
     # dim 2
-    AbelianStratum(0).hyperelliptic_component(): QQ((2,1)),
+    Stratum((0,), 1).hyperelliptic_component(): QQ((2,1)),
     # dim 4
-    AbelianStratum(2).hyperelliptic_component(): QQ((3,4)),
+    Stratum((2,), 1).hyperelliptic_component(): QQ((3,4)),
     # dim 5
-    AbelianStratum(1,1).hyperelliptic_component(): QQ((2,3)),
+    Stratum((1,1), 1).hyperelliptic_component(): QQ((2,3)),
     # dim 6
-    AbelianStratum(4).hyperelliptic_component(): QQ((9,64)),
-    AbelianStratum(4).odd_component(): QQ((7,18)),
+    Stratum((4,), 1).hyperelliptic_component(): QQ((9,64)),
+    Stratum((4,), 1).odd_component(): QQ((7,18)),
     # dim 7
-    AbelianStratum(3,1).unique_component(): QQ((16,45)),
-    AbelianStratum(2,2).hyperelliptic_component(): QQ((1,10)),
-    AbelianStratum(2,2).odd_component(): QQ((7,32)),
+    Stratum((3,1), 1).unique_component(): QQ((16,45)),
+    Stratum((2,2), 1).hyperelliptic_component(): QQ((1,10)),
+    Stratum((2,2), 1).odd_component(): QQ((7,32)),
     # dim 8
-    AbelianStratum(6).hyperelliptic_component(): QQ((25, 1536)),
-    AbelianStratum(6).odd_component(): QQ((1,4)),
-    AbelianStratum(6).even_component(): QQ((64,405)),
-    AbelianStratum(2,1,1).unique_component(): QQ((1,4)),
+    Stratum((6,), 1).hyperelliptic_component(): QQ((25, 1536)),
+    Stratum((6,), 1).odd_component(): QQ((1,4)),
+    Stratum((6,), 1).even_component(): QQ((64,405)),
+    Stratum((2,1,1), 1).unique_component(): QQ((1,4)),
     # dim 9
-    AbelianStratum(5,1).unique_component(): QQ((9,35)),
-    AbelianStratum(4,2).odd_component(): QQ((5,42)),
-    AbelianStratum(4,2).even_component(): QQ((45,512)),
-    AbelianStratum(3,3).non_hyperelliptic_component(): QQ((5,27)),
-    AbelianStratum(3,3).hyperelliptic_component(): QQ((1,105)),
-    AbelianStratum(1,1,1,1).unique_component(): QQ((7,36)),
+    Stratum((5,1), 1).unique_component(): QQ((9,35)),
+    Stratum((4,2), 1).odd_component(): QQ((5,42)),
+    Stratum((4,2), 1).even_component(): QQ((45,512)),
+    Stratum((3,3), 1).non_hyperelliptic_component(): QQ((5,27)),
+    Stratum((3,3), 1).hyperelliptic_component(): QQ((1,105)),
+    Stratum((1,1,1,1), 1).unique_component(): QQ((7,36)),
     # dim 10
-    # AbelianStratum(8).hyperelliptic_component()
-    # AbelianStratum(8).odd_component()
-    # AbelianStratum(8).even_component()
-    AbelianStratum(4,1,1).unique_component(): QQ((275,1728)),
-    AbelianStratum(3,2,1).unique_component(): QQ((2,15)),
-    AbelianStratum(2,2,2).odd_component(): QQ((155,2304)),
-    AbelianStratum(2,2,2).even_component(): QQ((37,720)),
+    # Stratum((8,), k=1).hyperelliptic_component()
+    # Stratum((8,), k=1).odd_component()
+    # Stratum((8,), k=1).even_component()
+    Stratum((4,1,1), 1).unique_component(): QQ((275,1728)),
+    Stratum((3,2,1), 1).unique_component(): QQ((2,15)),
+    Stratum((2,2,2), 1).odd_component(): QQ((155,2304)),
+    Stratum((2,2,2), 1).even_component(): QQ((37,720)),
     # dim 11
-    # AbelianStratum(7, 1)^c
-    # AbelianStratum(6, 2)^odd
-    # AbelianStratum(6, 2)^even
-    # AbelianStratum(5, 3)^c
-    # AbelianStratum(4^2)^hyp
-    # AbelianStratum(4^2)^odd
-    # AbelianStratum(4^2)^even
-    AbelianStratum(3,1,1,1).unique_component(): QQ((124,1215)),
-    AbelianStratum(2,2,1,1).unique_component(): QQ((131,1440))
+    # Stratum((7, 1), k=1).unique_component()
+    # Stratum((6, 2), k=1).odd_component()
+    # Stratum((6, 2), k=1).even_component()
+    # Stratum((5, 3), k=1).unique_component()
+    # Stratum((4, 4), k=1).hyperelliptic_component()
+    # Stratum((4, 4), k=1).odd_component()
+    # Stratum((4, 4), k=1).even_component()
+    Stratum((3,1,1,1), 1).unique_component(): QQ((124,1215)),
+    Stratum((2,2,1,1), 1).unique_component(): QQ((131,1440))
 }
 
 def masur_veech_volume(C, rational, method):
@@ -82,10 +83,10 @@ def masur_veech_volume(C, rational, method):
 
     TESTS::
 
-        sage: from surface_dynamics import AbelianStratum
+        sage: from surface_dynamics import Stratum
         sage: from surface_dynamics.flat_surfaces.masur_veech_volumes import masur_veech_volume
 
-        sage: H4 = AbelianStratum(4)
+        sage: H4 = Stratum([4], k=1)
         sage: masur_veech_volume(H4, False, 'table')
         61/108864*pi^6
         sage: masur_veech_volume(H4, False, 'CMSZ')
@@ -99,13 +100,13 @@ def masur_veech_volume(C, rational, method):
         sage: masur_veech_volume(H4.odd_component(), False, 'CMSZ')
         1/2430*pi^6
 
-        sage: H6 = AbelianStratum(6)
+        sage: H6 = Stratum([6], k=1)
         sage: all(masur_veech_volume(C, True, 'table') == masur_veech_volume(C, True, 'CMSZ') for C in H6.components())
         True
     """
     if method is None:
-        if (isinstance(C, AbelianStratum) and len(C.zeros()) == 1) or \
-           (isinstance(C, AbelianStratumComponent) and len(C.stratum().zeros()) == 1):
+        if (isinstance(C, AbelianStratum) and len(C.signature()) == 1) or \
+           (isinstance(C, AbelianStratumComponent) and len(C.stratum().signature()) == 1):
             method = 'CMSZ'
         else:
             method = 'table'
@@ -124,20 +125,20 @@ def masur_veech_volume(C, rational, method):
         else:
             raise ValueError('invalid input')
 
-        return vol if rational else vol * zeta(2 * S.genus())
+        return vol if rational else vol * zeta(2 * S.surface_genus())
 
     elif method == 'CMSZ':
         if isinstance(C, AbelianStratum):
-            if len(C.zeros()) != 1:
+            if len(C.signature()) != 1:
                 raise NotImplementedError
-            g = C.genus()
+            g = C.surface_genus()
             # be careful, the output starts in genus g=1
             return minimal_strata_CMSZ(g+1, rational=rational)[g-1]
         elif isinstance(C, AbelianStratumComponent):
             S = C.stratum()
-            if len(S.zeros()) != 1:
+            if len(S.signature()) != 1:
                 raise NotImplementedError
-            g = S.genus()
+            g = S.surface_genus()
             if C._name == 'hyp':
                 return minimal_strata_hyp(g, rational)
 
@@ -174,17 +175,17 @@ def minimal_strata_CMSZ(gmax, rational=False):
          12569/279936000*pi^8,
          12587/3311616000*pi^10]
 
-        sage: from surface_dynamics import AbelianStratum
+        sage: from surface_dynamics import Stratum
         sage: from surface_dynamics.flat_surfaces.masur_veech_volumes import masur_veech_volume
         sage: for rat in [True, False]:
         ....:     V0, V2, V4, V6 = minimal_strata_CMSZ(5, rational=rat)
-        ....:     MV0 = masur_veech_volume(AbelianStratum(0), rat, 'table')
+        ....:     MV0 = masur_veech_volume(Stratum([0], k=1), rat, 'table')
         ....:     assert V0 == MV0, (V0, MV0, rat)
-        ....:     MV2 = masur_veech_volume(AbelianStratum(2), rat, 'table')
+        ....:     MV2 = masur_veech_volume(Stratum([2], k=1), rat, 'table')
         ....:     assert V2 == MV2, (V2, MV2, rat)
-        ....:     MV4 = masur_veech_volume(AbelianStratum(4), rat, 'table')
+        ....:     MV4 = masur_veech_volume(Stratum([4], k=1), rat, 'table')
         ....:     assert V4 == MV4, (V4, MV4, rat)
-        ....:     MV6 = masur_veech_volume(AbelianStratum(6), rat, 'table')
+        ....:     MV6 = masur_veech_volume(Stratum([6], k=1), rat, 'table')
         ....:     assert V6 == MV6, (V6, MV6, rat)
     """
     n = 2 * gmax - 1

--- a/surface_dynamics/flat_surfaces/masur_veech_volumes.py
+++ b/surface_dynamics/flat_surfaces/masur_veech_volumes.py
@@ -64,11 +64,13 @@ abelian_volumes_table = {
     Stratum((2,2,1,1), 1).unique_component(): QQ((131,1440))
 }
 
-def masur_veech_volume(C, rational, method):
+def masur_veech_volume(C, rational=False, method=None):
     r"""
     Return the Masur-Veech volume of the stratum or component of stratum ``C``.
 
     INPUT:
+
+    - ``C`` -- a stratum or a connected component of stratum
 
     - ``rational`` (boolean) - if ``False`` (default) return the Masur-Veech volume
       and if ``True`` return the Masur-Veech volume divided by `\zeta(2g)`.
@@ -103,7 +105,24 @@ def masur_veech_volume(C, rational, method):
         sage: H6 = Stratum([6], k=1)
         sage: all(masur_veech_volume(C, True, 'table') == masur_veech_volume(C, True, 'CMSZ') for C in H6.components())
         True
+
+    TESTS::
+
+
+            sage: masur_veech_volume(Stratum([1,1,-2], k=1))
+            Traceback (most recent call last):
+            ...
+            ValueError: meromorphic differentials with higher order poles
+            sage: masur_veech_volume(Stratum([1]*6, k=3))
+            Traceback (most recent call last):
+            ...
+            NotImplementedError: higher order differentials
     """
+    if not C.surface_has_finite_area():
+        raise ValueError('meromorphic differentials with higher order poles')
+    if C.surface_differential_order() > 2:
+        raise NotImplementedError('higher order differentials')
+
     if method is None:
         if (isinstance(C, AbelianStratum) and len(C.signature()) == 1) or \
            (isinstance(C, AbelianStratumComponent) and len(C.stratum().signature()) == 1):
@@ -119,9 +138,9 @@ def masur_veech_volume(C, rational, method):
             vol = sum(abelian_volumes_table[CC] for CC in C.components())
             S = C
         elif isinstance(C, QuadraticStratumComponent):
-            raise NotImplementedError
+            raise NotImplementedError('quadratic differentials')
         elif isinstance(C, QuadraticStratum):
-            raise NotImplementedError
+            raise NotImplementedError('quadratic differentials')
         else:
             raise ValueError('invalid input')
 

--- a/surface_dynamics/flat_surfaces/origamis/origami_dense.pyx
+++ b/surface_dynamics/flat_surfaces/origamis/origami_dense.pyx
@@ -2154,7 +2154,7 @@ cdef class Origami_dense_pyx:
         cyl = self.cylinder_diagram()
         if cyl.is_hyperelliptic():
             return A.hyperelliptic_component()
-        elif any(d % 2 for d in A.zeros()):
+        elif any(d % 2 for d in A.signature()):
             return A.non_hyperelliptic_component()
         elif cyl.spin_parity() == 0:
             return A.even_component()
@@ -2261,7 +2261,7 @@ cdef class Origami_dense_pyx:
         if sf1 != sf2:
             return []
 
-        from surface_dynamics.flat_surfaces.quadratic_strata import QuadraticStratum
+        from surface_dynamics.flat_surfaces.strata import Stratum
 
         m = m2 * ~m1  # one element which reverses orientation
         if verbose:
@@ -2329,12 +2329,12 @@ cdef class Origami_dense_pyx:
 
             if points:
                 res.append((
-                    QuadraticStratum(qdegrees),
+                    Stratum(qdegrees, k=2),
                     vertices,
                     (squares, h_edges, v_edges)))
             else:
                 res.append((
-                    QuadraticStratum(qdegrees),
+                    Stratum(qdegrees, k=2),
                     tuple(len(c)-1 for c in vertices),
                     (len(squares), len(h_edges), len(v_edges))))
 
@@ -2368,7 +2368,7 @@ cdef class Origami_dense_pyx:
             (False, None)
         """
         for q, _, _ in self.orientation_data():
-            if q.genus() == 0:
+            if q.surface_genus() == 0:
                 if stratum:
                     return True, q
                 return True
@@ -3381,11 +3381,11 @@ cdef class Origami_dense_pyx:
             sage: o.stratum(True)
             H_4(3, 2, 1, 0^3)
         """
-        from surface_dynamics.flat_surfaces.abelian_strata import AbelianStratum
+        from surface_dynamics.flat_surfaces.strata import Stratum
         degrees = self.vertex_degrees(fake_zeros)
         if degrees:
-            return AbelianStratum(degrees)
-        return AbelianStratum(0)
+            return Stratum(degrees, k=1)
+        return Stratum([0], k=1)
 
     def genus(self):
         r"""
@@ -3401,7 +3401,7 @@ cdef class Origami_dense_pyx:
             sage: o.genus()
             2
         """
-        return self.stratum().genus()
+        return self.stratum().surface_genus()
 
     def veech_group(self):
         r"""
@@ -3802,9 +3802,9 @@ cpdef sl2z_orbits(origamis, int n, int limit):
 
     EXAMPLES::
 
-        sage: from surface_dynamics.all import AbelianStratum
+        sage: from surface_dynamics.all import Stratum
         sage: from surface_dynamics.flat_surfaces.origamis.origami_dense import sl2z_orbits
-        sage: C = AbelianStratum(2,2).odd_component()
+        sage: C = Stratum([2,2], k=1).odd_component()
         sage: origamis = C.origamis(10)
         sage: len(origamis)
         8955

--- a/surface_dynamics/flat_surfaces/origamis/pillowcase_cover.py
+++ b/surface_dynamics/flat_surfaces/origamis/pillowcase_cover.py
@@ -193,22 +193,22 @@ class PillowcaseCover_dense(PillowcaseCover_dense_pyx):
         """
         p = sum(self.profile(),[])
         if self.is_orientable():
-            from surface_dynamics.flat_surfaces.abelian_strata import AbelianStratum
+            from surface_dynamics.flat_surfaces.abelian_strata import Stratum
             if fake_zeros:
                 zeros = [(i-2)//2 for i in p]
             else:
                 zeros = [(i-2)//2 for i in p if i != 2]
             if not zeros:
-                return AbelianStratum([0])
-            return AbelianStratum(zeros)
+                return Stratum([0], k=1)
+            return Stratum(zeros, k=1)
 
         else:
-            from surface_dynamics.flat_surfaces.quadratic_strata import QuadraticStratum
+            from surface_dynamics.flat_surfaces.quadratic_strata import Stratum
             if fake_zeros:
                 zeros = [i-2 for i in p]
             else:
                 zeros = [i-2 for i in p if i != 2]
-            return QuadraticStratum(zeros)
+            return Stratum(zeros, k=2)
 
     def is_primitive(self, return_base=False):
         r"""

--- a/surface_dynamics/flat_surfaces/origamis/teichmueller_curve.py
+++ b/surface_dynamics/flat_surfaces/origamis/teichmueller_curve.py
@@ -16,6 +16,7 @@ from six.moves import range
 from sage.structure.sage_object import SageObject
 
 from sage.rings.integer import Integer
+from sage.rings.rational import Rational
 
 from sage.modular.arithgroup.arithgroup_perm import (EvenArithmeticSubgroup_Permutation, OddArithmeticSubgroup_Permutation)
 from copy import copy
@@ -373,10 +374,10 @@ class TeichmuellerCurveOfOrigami_class(TeichmuellerCurve):
 
         Kontsevich-Zorich formula
         """
-        K = Integer(1)/Integer(12) * sum(m*(m+2)/(m+1) for m in self.stratum().zeros())
+        K = Integer(1)/Integer(12) * sum(Integer(m)*Integer(m+2)/Integer(m+1) for m in self.stratum().signature())
         KK = 0
         for o in self._mapping:
-            KK += sum(w/h for (h,w) in o.widths_and_heights())
+            KK += sum(Rational((w,h)) for (h,w) in o.widths_and_heights())
         return K + Integer(1)/Integer(len(self._mapping)) * KK
 
     # TODO: mysterious signs and interversion problems...

--- a/surface_dynamics/flat_surfaces/separatrix_diagram.py
+++ b/surface_dynamics/flat_surfaces/separatrix_diagram.py
@@ -902,7 +902,7 @@ class SeparatrixDiagram(SageObject):
 
             sage: from surface_dynamics import *
 
-            sage: a = AbelianStratum(1,1,0)
+            sage: a = Stratum([1,1,0], k=1)
             sage: s = a.separatrix_diagrams()[0]
             sage: s.profile()
             [2, 2, 1]
@@ -965,9 +965,9 @@ class SeparatrixDiagram(SageObject):
             sage: SeparatrixDiagram('(0,1)(2)','(0,2)(1)').stratum()
             H_2(2)
         """
-        from .abelian_strata import AbelianStratum
+        from .abelian_strata import Stratum
 
-        return AbelianStratum([i-1 for i in self.profile()])
+        return Stratum([i-1 for i in self.profile()], k=1)
 
     def bot(self):
         r"""
@@ -1547,8 +1547,8 @@ class SeparatrixDiagram(SageObject):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import AbelianStratum
-            sage: H11 = AbelianStratum(1,1).unique_component()
+            sage: from surface_dynamics import Stratum
+            sage: H11 = Stratum([1,1], k=1).unique_component()
             sage: for cd in H11.cylinder_diagrams():
             ....:     fg = cd.saddle_connections_graph()
             ....:     print(cd.ncyls(), [comp.genus() for comp in fg.connected_components()])
@@ -1854,7 +1854,7 @@ def hyperelliptic_cylinder_diagram_iterator(a,verbose=False):
         sage: c.stratum_component()
         H_2(2)^hyp
 
-        sage: hyp = AbelianStratum(2,2).hyperelliptic_component()
+        sage: hyp = Stratum([2,2], k=1).hyperelliptic_component()
         sage: all(c.stratum_component() == hyp for c in hyperelliptic_cylinder_diagram_iterator(6))
         True
     """
@@ -2159,8 +2159,8 @@ class CylinderDiagram(SeparatrixDiagram):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import AbelianStratum
-            sage: for cd in AbelianStratum(1,1).cylinder_diagrams():
+            sage: from surface_dynamics import Stratum
+            sage: for cd in Stratum([1,1], k=1).cylinder_diagrams():
             ....:     print(cd.weighted_adjacency_matrix())
             [4]
             [0 1]
@@ -2280,7 +2280,7 @@ class CylinderDiagram(SeparatrixDiagram):
         r"""
         TESTS::
 
-            sage: from surface_dynamics import AbelianStratum, CylinderDiagram
+            sage: from surface_dynamics import Stratum, CylinderDiagram
 
             sage: c1 = CylinderDiagram('(0,5)-(0,4) (1,4)-(1,3) (2,3)-(2,5)')
             sage: c2 = CylinderDiagram('(0,5)-(1,3) (1,4)-(0,4) (2,3)-(2,5)')
@@ -2291,7 +2291,7 @@ class CylinderDiagram(SeparatrixDiagram):
             True
 
             sage: from operator import not_
-            sage: C = AbelianStratum(4).cylinder_diagrams()
+            sage: C = Stratum([4], k=1).cylinder_diagrams()
             sage: for c1 in C:
             ....:     assert c1 == c1
             ....:     assert not_(c1 != c1)
@@ -2313,9 +2313,9 @@ class CylinderDiagram(SeparatrixDiagram):
 
         TESTS::
 
-            sage: from surface_dynamics import AbelianStratum
+            sage: from surface_dynamics import Stratum
             sage: from operator import not_
-            sage: C = AbelianStratum(4).cylinder_diagrams()
+            sage: C = Stratum([4], k=1).cylinder_diagrams()
             sage: for c1 in C:
             ....:     for c2 in C:
             ....:         assert (c1 < c2) == (c2 > c1) == not_(c1 >= c2) == not_(c2 <= c1)
@@ -2706,7 +2706,7 @@ class CylinderDiagram(SeparatrixDiagram):
 
             sage: from surface_dynamics import *
 
-            sage: c0, c1 = AbelianStratum(2).cylinder_diagrams()
+            sage: c0, c1 = Stratum([2], k=1).cylinder_diagrams()
             sage: v0 = c0.volume_contribution()  # optional: latte_int
             sage: v0                             # optional: latte_int
             (1/3)/((w)^4)
@@ -2718,19 +2718,19 @@ class CylinderDiagram(SeparatrixDiagram):
             sage: v1.integral_sum_as_mzv()       # optional: latte_int
             2/3*ζ(1,3) + 1/3*ζ(2,2)
 
-            sage: for c in AbelianStratum(1,1).cylinder_diagrams():  # optional: latte_int
+            sage: for c in Stratum([1,1], k=1).cylinder_diagrams():  # optional: latte_int
             ....:     print(c, c.volume_contribution().integral_sum_as_mzv())
             (0,3,1,2)-(0,3,1,2) 1/6*ζ(5)
             (0)-(1) (1,2,3)-(0,2,3) 1/3*ζ(2,3) + 1/3*ζ(3,2)
             (0,3)-(1,3) (1,2)-(0,2) ζ(1,4) + 1/3*ζ(2,3)
             (0,1)-(2,3) (2)-(1) (3)-(0) 1/3*ζ(1,3) + 1/3*ζ(2,2) - 1/3*ζ(2,3) - 1/3*ζ(3,2) + 1/3*ζ(4) - 1/3*ζ(5)
 
-            sage: sum(c.volume_contribution() for c in AbelianStratum(2,1,1).cylinder_diagrams(1)).integral_sum_as_mzv()  # optional: latte_int
+            sage: sum(c.volume_contribution() for c in Stratum([2,1,1], k=1).cylinder_diagrams(1)).integral_sum_as_mzv()  # optional: latte_int
             7/180*ζ(8)
 
         Detailed contribution of 2 cylinder diagrams::
 
-            sage: cyls = AbelianStratum(2,1,1).cylinder_diagrams(2)
+            sage: cyls = Stratum([2,1,1], k=1).cylinder_diagrams(2)
             sage: sum(cyls[k].volume_contribution() for k in [2,7,8,21,22]).integral_sum_as_mzv()  # optional: latte_int
             13/630*ζ(5,3) + 13/252*ζ(6,2)
             sage: sum(cyls[k].volume_contribution() for k in [0,11,19,20]).integral_sum_as_mzv()  # optional: latte_int
@@ -2914,7 +2914,7 @@ class CylinderDiagram(SeparatrixDiagram):
 
         The inversion is an involution on cylinder diagrams::
 
-            sage: all(cc.inverse().inverse() == cc for cc in AbelianStratum(4).cylinder_diagrams()) # long time
+            sage: all(cc.inverse().inverse() == cc for cc in Stratum([4], k=1).cylinder_diagrams()) # long time
             True
         """
         return CylinderDiagram([(t,b) for (b,t) in self.cylinders()])
@@ -2935,7 +2935,7 @@ class CylinderDiagram(SeparatrixDiagram):
             sage: c.separatrix_diagram().vertical_symmetry() == c.vertical_symmetry().separatrix_diagram()
             True
 
-            sage: A = AbelianStratum(2,2)
+            sage: A = Stratum([2,2], k=1)
             sage: all(c.vertical_symmetry().stratum() == A for c in A.cylinder_diagrams())
             True
         """
@@ -2957,7 +2957,7 @@ class CylinderDiagram(SeparatrixDiagram):
             sage: c.separatrix_diagram().horizontal_symmetry() == c.horizontal_symmetry().separatrix_diagram()
             True
 
-            sage: A = AbelianStratum(2,2)
+            sage: A = Stratum([2,2], k=1)
             sage: all(c.horizontal_symmetry().stratum() == A for c in A.cylinder_diagrams())
             True
         """
@@ -3087,12 +3087,12 @@ class CylinderDiagram(SeparatrixDiagram):
 
         In genus 2, strata H(2) and H(1,1), all surfaces are hyperelliptic::
 
-            sage: for c in AbelianStratum(2).cylinder_diagrams():
+            sage: for c in Stratum([2], k=1).cylinder_diagrams():
             ....:     print("%d %s" % (c.ncyls(), c.is_hyperelliptic()))
             1 True
             2 True
 
-            sage: for c in AbelianStratum(1,1).cylinder_diagrams():
+            sage: for c in Stratum([1,1], k=1).cylinder_diagrams():
             ....:     print("%d %s" % (c.ncyls(), c.is_hyperelliptic()))
             1 True
             2 True
@@ -3101,19 +3101,19 @@ class CylinderDiagram(SeparatrixDiagram):
 
         In higher genera, some of them are, some of them are not::
 
-            sage: C = AbelianStratum(4).cylinder_diagrams()
+            sage: C = Stratum([4], k=1).cylinder_diagrams()
             sage: len(C)
             15
             sage: sum(c.is_hyperelliptic() for c in C)
             5
 
-            sage: C = AbelianStratum(2,2).cylinder_diagrams()
+            sage: C = Stratum([2,2], k=1).cylinder_diagrams()
             sage: len(C)
             41
             sage: sum(c.is_hyperelliptic() for c in C)
             11
         """
-        z = self.stratum().zeros()
+        z = self.stratum().signature()
         if z == [0] or z == [2] or z == [1,1]: return True
         if 0 in z:
             raise NotImplementedError("is_hyperelliptic method not implemented for cylinder diagrams with fake zeros")
@@ -3271,8 +3271,8 @@ class CylinderDiagram(SeparatrixDiagram):
                 ('%dt' %self._top_to_cyl[i][1]))
 
         # the dual graph
-        G = Graph(loops=True,multiedges=True)
-        cc = map(tuple,V.connected_components())
+        G = Graph(loops=True, multiedges=True)
+        cc = map(tuple, V.connected_components(sort=False))
         hc2cc = {} # half-cyl to conn comp
         for c in cc:
             for e in c:
@@ -3348,24 +3348,24 @@ class CylinderDiagram(SeparatrixDiagram):
             sage: c.stratum_component()
             H_5(4^2)^odd
         """
+        # TODO: we reimplement the very same logic in interval_exchanges.template.stratum_component()
         stratum = self.stratum()
-        cc = stratum._cc
-        if len(cc) == 1:
-            return cc[0](stratum)
 
-        from .abelian_strata import HypASC
-        if cc[0] is HypASC:
+        if stratum.is_connected():
+            return stratum.unique_component()
+
+        if stratum.has_hyperelliptic_component():
             if self.is_hyperelliptic():
-                return HypASC(stratum)
-            elif len(cc) == 2:
-                return cc[1](stratum)
+                return stratum.hyperelliptic_component()
+            # TODO: we assume that the first entry is the hyperelliptic one
+            cc = stratum.connected_components()
+            if len(cc) == 2:
+                return cc[1]
 
         if self.spin_parity() == 0:
-            from .abelian_strata import EvenASC
-            return EvenASC(stratum)
+            return stratum.even_component()
         else:
-            from .abelian_strata import OddASC
-            return OddASC(stratum)
+            return stratum.odd_component()
 
     def smallest_integer_lengths(self):
         r"""
@@ -3453,10 +3453,10 @@ class CylinderDiagram(SeparatrixDiagram):
 
             sage: f = lambda c: c.to_ribbon_graph().cycle_basis(intersection=True)[1]
 
-            sage: a = AbelianStratum(2)
+            sage: a = Stratum([2], k=1)
             sage: all(f(c).rank() == 4 for c in a.cylinder_diagrams())
             True
-            sage: a = AbelianStratum(1,1)
+            sage: a = Stratum([1,1], k=1)
             sage: all(f(c).rank() == 4 for c in a.cylinder_diagrams())
             True
         """
@@ -3500,8 +3500,6 @@ class CylinderDiagram(SeparatrixDiagram):
 
         return RibbonGraphWithHolonomies(edges=edges,faces=faces,holonomies=holonomies)
 
-
-
     def spin_parity(self):
         r"""
         Return the spin parity of any surface that is built from this cylinder
@@ -3525,7 +3523,7 @@ class CylinderDiagram(SeparatrixDiagram):
             sage: c.spin_parity()
             1
         """
-        if any(z%2 for z in self.stratum().zeros()):
+        if any(z % 2 for z in self.stratum().signature()):
             return None
         return self.to_ribbon_graph().spin_parity()
 
@@ -3906,7 +3904,7 @@ class CylinderDiagram(SeparatrixDiagram):
             sage: o2 = o2.relabel()
             sage: o3 = c.cylcoord_to_origami([2,1,2],[1,1],[1,1])
             sage: o3 = o3.relabel()
-            sage: all(o.stratum() == AbelianStratum(2) for o in [o1,o2,o3])
+            sage: all(o.stratum() == Stratum([2], k=1) for o in [o1,o2,o3])
             True
             sage: o1 == o2 or o1 == o3 or o3 == o1
             False
@@ -4388,8 +4386,8 @@ class QuadraticCylinderDiagram(SageObject):
             sage: QuadraticCylinderDiagram('(0,1)-(2,3) (0)-(4,4) (1)-(5,5) (2)-(6,6) (3)-(7,7)').stratum()
             Q_0(2^2, -1^8)
         """
-        from surface_dynamics.flat_surfaces.quadratic_strata import QuadraticStratum
-        return QuadraticStratum([len(t)-2 for t in self._g._vertex_cycles])
+        from surface_dynamics.flat_surfaces.quadratic_strata import Stratum
+        return Stratum([len(t)-2 for t in self._g._vertex_cycles], k=2)
 
     def cylinders(self, dart=False):
         r"""

--- a/surface_dynamics/flat_surfaces/separatrix_diagram.py
+++ b/surface_dynamics/flat_surfaces/separatrix_diagram.py
@@ -4773,7 +4773,7 @@ class QuadraticCylinderDiagram(SageObject):
 
         return dart_to_corner
 
-    # figure out whether this awfull method is really useful...
+    # figure out whether this awful method is really useful...
     # square tiled quadratic surface would be much more simple to handle
     def cylcoord_to_pillowcase_cover(self, lengths, heights, twists=None, verbose=False):
         r"""

--- a/surface_dynamics/flat_surfaces/single_cylinder.py
+++ b/surface_dynamics/flat_surfaces/single_cylinder.py
@@ -32,7 +32,7 @@ Check for non-hyperelliptic strata::
 """
 
 from surface_dynamics.interval_exchanges.constructors import GeneralizedPermutation
-from surface_dynamics.flat_surfaces.abelian_strata import AbelianStratum
+from surface_dynamics.flat_surfaces.strata import Stratum
 
 def _cylinder_check(perm):
     r"""
@@ -97,7 +97,7 @@ def even_zero_odd(num):
         sage: perm
         0 1 2 3 4 5
         2 5 4 1 3 0
-        sage: perm.stratum_component() == AbelianStratum(4).odd_component()
+        sage: perm.stratum_component() == Stratum([4], k=1).odd_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -105,7 +105,7 @@ def even_zero_odd(num):
         sage: perm
         0 1 2 3 4 5 6 7
         2 5 4 7 3 1 6 0
-        sage: perm.stratum_component() == AbelianStratum(6).odd_component()
+        sage: perm.stratum_component() == Stratum([6], k=1).odd_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -149,7 +149,7 @@ def no_two_odd(real_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12
         2 5 4 7 3 8 6 9 12 11 1 10 0
-        sage: perm.stratum_component() == AbelianStratum(6,4).odd_component()
+        sage: perm.stratum_component() == Stratum([6,4], k=1).odd_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -188,7 +188,7 @@ def one_two_odd(real_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8
         2 5 8 3 6 4 1 7 0
-        sage: perm.stratum_component() == AbelianStratum(4,2).odd_component()
+        sage: perm.stratum_component() == Stratum([4,2], k=1).odd_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -196,7 +196,7 @@ def one_two_odd(real_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19
         2 5 4 7 3 8 6 10 12 9 13 11 14 17 16 19 15 1 18 0
-        sage: perm.stratum_component() == AbelianStratum(8,6,2).odd_component()
+        sage: perm.stratum_component() == Stratum([8,6,2], k=1).odd_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -258,7 +258,7 @@ def even_twos_odd(real_zeros,two_count):
         sage: perm
         0 1 2 3 4 5 6
         2 4 6 3 1 5 0
-        sage: perm.stratum_component() == AbelianStratum(2,2).odd_component()
+        sage: perm.stratum_component() == Stratum([2,2], k=1).odd_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -266,7 +266,7 @@ def even_twos_odd(real_zeros,two_count):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17
         2 4 6 3 7 5 8 10 12 9 13 11 14 17 16 1 15 0
-        sage: perm.stratum_component() == AbelianStratum({4:1,2:4}).odd_component()
+        sage: perm.stratum_component() == Stratum({4:1,2:4}, k=1).odd_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -315,7 +315,7 @@ def odd_twos_odd(real_zeros,two_count):
         sage: perm
         0 1 2 3 4 5 6 7 8 9
         2 8 6 9 4 1 3 5 7 0
-        sage: perm.stratum_component() == AbelianStratum(2,2,2).odd_component()
+        sage: perm.stratum_component() == Stratum([2,2,2], k=1).odd_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -323,7 +323,7 @@ def odd_twos_odd(real_zeros,two_count):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
         2 8 6 9 4 10 3 5 7 11 13 15 12 16 14 17 20 19 1 18 0
-        sage: perm.stratum_component() == AbelianStratum({4:1,2:5}).odd_component()
+        sage: perm.stratum_component() == Stratum({4:1,2:5}, k=1).odd_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -372,7 +372,7 @@ def even_zero_even(num):
         sage: perm
         0 1 2 3 4 5 6 7
         2 7 6 5 3 1 4 0
-        sage: perm.stratum_component() == AbelianStratum(6).even_component()
+        sage: perm.stratum_component() == Stratum([6], k=1).even_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -380,7 +380,7 @@ def even_zero_even(num):
         sage: perm
         0 1 2 3 4 5 6 7 8 9
         2 7 6 5 3 9 4 1 8 0
-        sage: perm.stratum_component() == AbelianStratum(8).even_component()
+        sage: perm.stratum_component() == Stratum([8], k=1).even_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -425,7 +425,7 @@ def no_two_even(real_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10
         2 10 7 5 8 1 9 6 4 3 0
-        sage: perm.stratum_component() == AbelianStratum(4,4).even_component()
+        sage: perm.stratum_component() == Stratum([4,4], k=1).even_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -433,7 +433,7 @@ def no_two_even(real_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12
         2 7 6 5 3 8 4 9 12 11 1 10 0
-        sage: perm.stratum_component() == AbelianStratum(6,4).even_component()
+        sage: perm.stratum_component() == Stratum([6,4], k=1).even_component()
         True
 
     """
@@ -444,7 +444,7 @@ def no_two_even(real_zeros):
         real_zeros.remove(4)
 
         if real_zeros:
-            odd_perm = AbelianStratum(real_zeros).odd_component().single_cylinder_representative()
+            odd_perm = Stratum(real_zeros, k=1).odd_component().single_cylinder_representative()
             return cylinder_concatenation(even_4_4,odd_perm)
         else:
             return even_4_4
@@ -453,7 +453,7 @@ def no_two_even(real_zeros):
         if len(real_zeros) == 1:
             return perm
         else:
-            odd_perm = AbelianStratum(real_zeros[1:]).odd_component().single_cylinder_representative()
+            odd_perm = Stratum(real_zeros[1:], k=1).odd_component().single_cylinder_representative()
             return cylinder_concatenation(perm,odd_perm)
 
 
@@ -482,7 +482,7 @@ def one_two_even(real_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8
         2 4 1 8 7 5 3 6 0
-        sage: perm.stratum_component() == AbelianStratum(4,2).even_component()
+        sage: perm.stratum_component() == Stratum([4,2], k=1).even_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -490,7 +490,7 @@ def one_two_even(real_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10
         2 10 9 8 6 3 5 1 4 7 0
-        sage: perm.stratum_component() == AbelianStratum(6,2).even_component()
+        sage: perm.stratum_component() == Stratum([6,2], k=1).even_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -498,7 +498,7 @@ def one_two_even(real_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19
         2 7 6 5 3 8 4 10 12 9 13 11 14 17 16 19 15 1 18 0
-        sage: perm.stratum_component() == AbelianStratum(8,6,2).even_component()
+        sage: perm.stratum_component() == Stratum([8,6,2], k=1).even_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -516,11 +516,11 @@ def one_two_even(real_zeros):
         real_zeros.remove(2)
         if set(real_zeros) == {4}:
             perm = GeneralizedPermutation([0,1,2,3,4,5,6,7,8],[2,4,1,8,7,5,3,6,0])
-            odd_perm = AbelianStratum(real_zeros[1:]).odd_component().single_cylinder_representative()
+            odd_perm = Stratum(real_zeros[1:], k=1).odd_component().single_cylinder_representative()
             return cylinder_concatenation(perm,odd_perm)
         elif set(real_zeros) == {6} or set(real_zeros) == {4, 6}:
             perm = GeneralizedPermutation([0,1,2,3,4,5,6,7,8,9,10],[2,10,9,8,6,3,5,1,4,7,0])
-            odd_perm = AbelianStratum(real_zeros[1:]).odd_component().single_cylinder_representative()
+            odd_perm = Stratum(real_zeros[1:], k=1).odd_component().single_cylinder_representative()
             return cylinder_concatenation(perm,odd_perm)
         else:
             perm_1 = even_zero_even(real_zeros[0]-2)
@@ -538,7 +538,7 @@ def one_two_even(real_zeros):
             if len(real_zeros) == 1:
                 return perm
             else:
-                odd_perm = AbelianStratum(real_zeros[1:]).odd_component().single_cylinder_representative()
+                odd_perm = Stratum(real_zeros[1:], k=1).odd_component().single_cylinder_representative()
                 return cylinder_concatenation(perm,odd_perm)
 
 def two_twos_even(real_zeros):
@@ -566,7 +566,7 @@ def two_twos_even(real_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11
         2 8 5 3 1 10 9 6 4 11 7 0
-        sage: perm.stratum_component() == AbelianStratum(4,2,2).even_component()
+        sage: perm.stratum_component() == Stratum([4,2,2], k=1).even_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -574,7 +574,7 @@ def two_twos_even(real_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12 13
         2 7 6 5 3 8 4 9 11 13 10 1 12 0
-        sage: perm.stratum_component() == AbelianStratum(6,2,2).even_component()
+        sage: perm.stratum_component() == Stratum([6,2,2], k=1).even_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -587,7 +587,7 @@ def two_twos_even(real_zeros):
         if len(real_zeros) == 1:
             return perm
         else:
-            odd_perm = AbelianStratum(real_zeros[1:]).odd_component().single_cylinder_representative()
+            odd_perm = Stratum(real_zeros[1:], k=1).odd_component().single_cylinder_representative()
             return cylinder_concatenation(perm,odd_perm)
     else:
         odd_2_2 = GeneralizedPermutation([0,1,2,3,4,5,6],[2,4,6,3,1,5,0])
@@ -595,7 +595,7 @@ def two_twos_even(real_zeros):
         if len(real_zeros) == 1:
             return perm
         else:
-            odd_perm = AbelianStratum(real_zeros[1:]).odd_component().single_cylinder_representative()
+            odd_perm = Stratum(real_zeros[1:], k=1).odd_component().single_cylinder_representative()
             return cylinder_concatenation(perm,odd_perm)
 
 def even_twos_even(real_zeros,two_count):
@@ -626,7 +626,7 @@ def even_twos_even(real_zeros,two_count):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12
         2 5 4 1 12 3 10 7 11 9 6 8 0
-        sage: perm.stratum_component() == AbelianStratum(2,2,2,2).even_component()
+        sage: perm.stratum_component() == Stratum([2,2,2,2], k=1).even_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -634,7 +634,7 @@ def even_twos_even(real_zeros,two_count):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23
         2 5 4 13 12 3 10 7 11 9 6 8 14 16 18 15 19 17 20 23 22 1 21 0
-        sage: perm.stratum_component() == AbelianStratum({4:1,2:6}).even_component()
+        sage: perm.stratum_component() == Stratum({4:1,2:6}, k=1).even_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -649,7 +649,7 @@ def even_twos_even(real_zeros,two_count):
     if not real_zeros:
         return twos_perm
     else:
-        odd_perm = AbelianStratum(real_zeros).odd_component().single_cylinder_representative()
+        odd_perm = Stratum(real_zeros, k=1).odd_component().single_cylinder_representative()
         return cylinder_concatenation(twos_perm,odd_perm)
 
 
@@ -681,7 +681,7 @@ def odd_twos_even(real_zeros,two_count):
         sage: perm
         0 1 2 3 4 5 6 7 8 9
         2 9 8 7 6 3 5 1 4 0
-        sage: perm.stratum_component() == AbelianStratum(2,2,2).even_component()
+        sage: perm.stratum_component() == Stratum([2,2,2], k=1).even_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -689,7 +689,7 @@ def odd_twos_even(real_zeros,two_count):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
         2 9 8 7 6 3 5 10 4 11 13 15 12 16 14 17 20 19 1 18 0
-        sage: perm.stratum_component() == AbelianStratum({4:1,2:5}).even_component()
+        sage: perm.stratum_component() == Stratum({4:1,2:5}, k=1).even_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -705,7 +705,7 @@ def odd_twos_even(real_zeros,two_count):
     if not real_zeros:
         return twos_perm
     else:
-        odd_perm = AbelianStratum(real_zeros).odd_component().single_cylinder_representative()
+        odd_perm = Stratum(real_zeros, k=1).odd_component().single_cylinder_representative()
         return cylinder_concatenation(twos_perm,odd_perm)
 
 
@@ -736,7 +736,7 @@ def odds_right_swap(zero_pair):
         sage: perm
         0 1 2 3 4 5 6 7 8
         2 8 6 5 7 4 1 3 0
-        sage: perm.stratum_component() == AbelianStratum(3,3).non_hyperelliptic_component()
+        sage: perm.stratum_component() == Stratum([3,3], k=1).non_hyperelliptic_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -744,7 +744,7 @@ def odds_right_swap(zero_pair):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12
         2 5 4 7 3 9 6 12 8 11 1 10 0
-        sage: perm.stratum_component() == AbelianStratum(5,5).non_hyperelliptic_component()
+        sage: perm.stratum_component() == Stratum([5,5], k=1).non_hyperelliptic_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -752,7 +752,7 @@ def odds_right_swap(zero_pair):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10
         2 5 4 7 3 10 6 9 1 8 0
-        sage: perm.stratum_component() == AbelianStratum(5,3).unique_component()
+        sage: perm.stratum_component() == Stratum([5,3], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -765,8 +765,8 @@ def odds_right_swap(zero_pair):
             j = (min(zero_pair)-3)//2
         else:
             j = (min(zero_pair)-1)//2
-        perm_1 = AbelianStratum(4*j+2-dif).odd_component().single_cylinder_representative()
-        perm_2 = AbelianStratum(4).odd_component().single_cylinder_representative()
+        perm_1 = Stratum([4*j+2-dif], k=1).odd_component().single_cylinder_representative()
+        perm_2 = Stratum([4], k=1).odd_component().single_cylinder_representative()
         perm = cylinder_concatenation(perm_1,perm_2)
         top_row = perm[0][1:]
         bot_row = perm[1][:-1]
@@ -805,7 +805,7 @@ def odds_left_swap(zero_pair):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12
         2 5 4 8 3 7 9 6 12 11 1 10 0
-        sage: perm.stratum_component() == AbelianStratum(7,3).unique_component()
+        sage: perm.stratum_component() == Stratum([7,3], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -813,15 +813,15 @@ def odds_left_swap(zero_pair):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18
         2 5 4 7 3 9 6 12 8 11 13 10 16 15 18 14 1 17 0
-        sage: perm.stratum_component() == AbelianStratum(11,5).unique_component()
+        sage: perm.stratum_component() == Stratum([11,5], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
     """
     dif = abs(zero_pair[0]-zero_pair[1])
     j = (min(zero_pair)-1)//2
-    perm_1 = AbelianStratum(4*j+2).odd_component().single_cylinder_representative()
-    perm_2 = AbelianStratum(dif).odd_component().single_cylinder_representative()
+    perm_1 = Stratum([4*j+2], k=1).odd_component().single_cylinder_representative()
+    perm_2 = Stratum([dif], k=1).odd_component().single_cylinder_representative()
     perm = cylinder_concatenation(perm_1,perm_2)
     swap_point = len(perm_2[0])-1
     top_row = perm[0][1:]
@@ -860,7 +860,7 @@ def no_ones_odds(odd_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12
         2 5 4 8 3 7 9 6 12 11 1 10 0
-        sage: perm.stratum_component() == AbelianStratum(7,3).unique_component()
+        sage: perm.stratum_component() == Stratum([7,3], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -868,7 +868,7 @@ def no_ones_odds(odd_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18
         2 5 4 7 3 10 6 9 11 8 12 18 16 15 17 14 1 13 0
-        sage: perm.stratum_component() == AbelianStratum(5,3,3,3).unique_component()
+        sage: perm.stratum_component() == Stratum([5,3,3,3], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -909,7 +909,7 @@ def one_one_odds(odd_zeros):
         sage: perm
         0 1 2 3 4 5 6
         2 5 1 6 4 3 0
-        sage: perm.stratum_component() == AbelianStratum(3,1).unique_component()
+        sage: perm.stratum_component() == Stratum([3,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -917,7 +917,7 @@ def one_one_odds(odd_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8
         2 4 7 3 1 8 6 5 0
-        sage: perm.stratum_component() == AbelianStratum(5,1).unique_component()
+        sage: perm.stratum_component() == Stratum([5,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -925,7 +925,7 @@ def one_one_odds(odd_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18
         2 5 4 9 3 8 6 11 10 7 12 18 16 15 17 14 1 13 0
-        sage: perm.stratum_component() == AbelianStratum(7,3,3,1).unique_component()
+        sage: perm.stratum_component() == Stratum([7,3,3,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -947,7 +947,7 @@ def one_one_odds(odd_zeros):
             return cylinder_concatenation(perm,no_ones_odds(odd_zeros[1:]))
     else:
         odd_zeros.remove(1)
-        perm_1 = AbelianStratum(num-3).odd_component().single_cylinder_representative()
+        perm_1 = Stratum([num-3], k=1).odd_component().single_cylinder_representative()
         length_1 = len(perm_1[0])-1
         top_row_1 = perm_1[0]
         bot_row_1 = perm_1[1][:-1]
@@ -990,7 +990,7 @@ def two_ones_odds(odd_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12
         2 5 7 6 4 3 8 11 1 12 10 9 0
-        sage: perm.stratum_component() == AbelianStratum(3,3,1,1).unique_component()
+        sage: perm.stratum_component() == Stratum([3,3,1,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -998,7 +998,7 @@ def two_ones_odds(odd_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24
         2 4 7 3 9 8 6 5 10 12 15 11 17 16 14 13 18 24 22 21 23 20 1 19 0
-        sage: perm.stratum_component() == AbelianStratum(5,5,3,3,1,1).unique_component()
+        sage: perm.stratum_component() == Stratum([5,5,3,3,1,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1037,7 +1037,7 @@ def three_ones_odds(odd_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10
         2 10 6 5 1 8 4 7 3 9 0
-        sage: perm.stratum_component() == AbelianStratum(3,1,1,1).unique_component()
+        sage: perm.stratum_component() == Stratum([3,1,1,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1045,7 +1045,7 @@ def three_ones_odds(odd_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12
         2 12 9 8 1 7 3 6 10 5 4 11 0
-        sage: perm.stratum_component() == AbelianStratum(5,1,1,1).unique_component()
+        sage: perm.stratum_component() == Stratum([5,1,1,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1053,7 +1053,7 @@ def three_ones_odds(odd_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12 13 14
         2 14 10 9 1 4 3 6 5 12 8 11 7 13 0
-        sage: perm.stratum_component() == AbelianStratum(7,1,1,1).unique_component()
+        sage: perm.stratum_component() == Stratum([7,1,1,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1065,7 +1065,7 @@ def three_ones_odds(odd_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18
         2 5 7 6 4 3 8 11 13 12 10 9 14 17 1 18 16 15 0
-        sage: perm.stratum_component() == AbelianStratum(3,3,3,1,1,1).unique_component()
+        sage: perm.stratum_component() == Stratum([3,3,3,1,1,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1126,7 +1126,7 @@ def even_ones_odds(odd_zeros,one_count):
         sage: perm
         0 1 2 3 4 5 6 7 8
         2 6 5 3 1 8 4 7 0
-        sage: perm.stratum_component() == AbelianStratum(1,1,1,1).unique_component()
+        sage: perm.stratum_component() == Stratum([1,1,1,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1134,7 +1134,7 @@ def even_ones_odds(odd_zeros,one_count):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12
         2 8 1 5 11 7 3 10 6 12 9 4 0
-        sage: perm.stratum_component() == AbelianStratum(1,1,1,1,1,1).unique_component()
+        sage: perm.stratum_component() == Stratum([1,1,1,1,1,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1142,7 +1142,7 @@ def even_ones_odds(odd_zeros,one_count):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18
         2 6 5 3 9 8 4 7 10 13 12 15 11 18 14 17 1 16 0
-        sage: perm.stratum_component() == AbelianStratum(5,3,1,1,1,1).unique_component()
+        sage: perm.stratum_component() == Stratum([5,3,1,1,1,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1150,7 +1150,7 @@ def even_ones_odds(odd_zeros,one_count):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
         2 8 13 5 11 7 3 10 6 12 9 4 14 20 18 17 19 16 1 15 0
-        sage: perm.stratum_component() == AbelianStratum(3,3,1,1,1,1,1,1).unique_component()
+        sage: perm.stratum_component() == Stratum([3,3,1,1,1,1,1,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1201,7 +1201,7 @@ def odd_ones_odds(odd_zeros,one_count):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16
         2 4 7 3 9 8 6 5 10 14 13 11 1 16 12 15 0
-        sage: perm.stratum_component() == AbelianStratum(5,1,1,1,1,1).unique_component()
+        sage: perm.stratum_component() == Stratum([5,1,1,1,1,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1209,7 +1209,7 @@ def odd_ones_odds(odd_zeros,one_count):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18
         2 5 7 6 4 3 8 14 1 11 17 13 9 16 12 18 15 10 0
-        sage: perm.stratum_component() == AbelianStratum(3,1,1,1,1,1,1,1).unique_component()
+        sage: perm.stratum_component() == Stratum([3,1,1,1,1,1,1,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1247,7 +1247,7 @@ def min_on_bot(zero_pair):
         sage: perm
         0 1 2 3 4 5 6
         2 6 5 1 4 3 0
-        sage: perm.stratum_component() == AbelianStratum(3,1).unique_component()
+        sage: perm.stratum_component() == Stratum([3,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1255,7 +1255,7 @@ def min_on_bot(zero_pair):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10
         2 6 4 10 8 3 1 9 7 5 0
-        sage: perm.stratum_component() == AbelianStratum(5,3).unique_component()
+        sage: perm.stratum_component() == Stratum([5,3], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1263,7 +1263,7 @@ def min_on_bot(zero_pair):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12 13 14
         2 6 4 10 8 3 12 9 7 5 14 11 1 13 0
-        sage: perm.stratum_component() == AbelianStratum(7,5).unique_component()
+        sage: perm.stratum_component() == Stratum([7,5], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1306,7 +1306,7 @@ def odd_zeros_one_one(odd_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12
         2 5 4 7 3 9 6 12 8 11 1 10 0
-        sage: perm.stratum_component() == AbelianStratum(5,5).non_hyperelliptic_component()
+        sage: perm.stratum_component() == Stratum([5,5], k=1).non_hyperelliptic_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1314,7 +1314,7 @@ def odd_zeros_one_one(odd_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8
         2 4 7 3 1 8 6 5 0
-        sage: perm.stratum_component() == AbelianStratum(5,1).unique_component()
+        sage: perm.stratum_component() == Stratum([5,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1322,7 +1322,7 @@ def odd_zeros_one_one(odd_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12 13 14
         2 4 7 3 9 8 6 5 10 13 1 14 12 11 0
-        sage: perm.stratum_component() == AbelianStratum(5,3,1,1).unique_component()
+        sage: perm.stratum_component() == Stratum([5,3,1,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1330,7 +1330,7 @@ def odd_zeros_one_one(odd_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12
         2 12 9 8 1 7 3 6 10 5 4 11 0
-        sage: perm.stratum_component() == AbelianStratum(5,1,1,1).unique_component()
+        sage: perm.stratum_component() == Stratum([5,1,1,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1338,7 +1338,7 @@ def odd_zeros_one_one(odd_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18
         2 6 5 3 9 8 4 7 10 13 12 15 11 18 14 17 1 16 0
-        sage: perm.stratum_component() == AbelianStratum(5,3,1,1,1,1).unique_component()
+        sage: perm.stratum_component() == Stratum([5,3,1,1,1,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1346,7 +1346,7 @@ def odd_zeros_one_one(odd_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16
         2 4 7 3 9 8 6 5 10 14 13 11 1 16 12 15 0
-        sage: perm.stratum_component() == AbelianStratum(5,1,1,1,1,1).unique_component()
+        sage: perm.stratum_component() == Stratum([5,1,1,1,1,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1390,7 +1390,7 @@ def only_even_2(odd_zeros):
         sage: perm
         0 1 2 3 4 5 6 7
         2 6 4 1 7 5 3 0
-        sage: perm.stratum_component() == AbelianStratum(2,1,1).unique_component()
+        sage: perm.stratum_component() == Stratum([2,1,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1398,7 +1398,7 @@ def only_even_2(odd_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15
         2 6 4 8 7 5 3 9 13 12 10 1 15 11 14 0
-        sage: perm.stratum_component() == AbelianStratum({2:1,1:6}).unique_component()
+        sage: perm.stratum_component() == Stratum({2:1,1:6}, k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1406,7 +1406,7 @@ def only_even_2(odd_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11
         2 7 11 6 3 9 5 1 8 4 10 0
-        sage: perm.stratum_component() == AbelianStratum(2,1,1,1,1).unique_component()
+        sage: perm.stratum_component() == Stratum([2,1,1,1,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1414,7 +1414,7 @@ def only_even_2(odd_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19
         2 7 11 6 3 9 5 12 8 4 10 13 17 16 14 1 19 15 18 0
-        sage: perm.stratum_component() == AbelianStratum({2:1,1:8}).unique_component()
+        sage: perm.stratum_component() == Stratum({2:1,1:8}, k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1422,7 +1422,7 @@ def only_even_2(odd_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15
         2 6 4 8 7 5 3 9 15 13 12 14 11 1 10 0
-        sage: perm.stratum_component() == AbelianStratum(3,3,2,1,1).unique_component()
+        sage: perm.stratum_component() == Stratum([3,3,2,1,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1430,7 +1430,7 @@ def only_even_2(odd_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12 13
         2 6 4 8 7 5 3 9 12 1 13 11 10 0
-        sage: perm.stratum_component() == AbelianStratum(3,2,1,1,1).unique_component()
+        sage: perm.stratum_component() == Stratum([3,2,1,1,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1438,7 +1438,7 @@ def only_even_2(odd_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21
         2 8 6 5 7 4 9 3 11 13 10 14 12 15 21 19 18 20 17 1 16 0
-        sage: perm.stratum_component() == AbelianStratum(5,3,3,3,2).unique_component()
+        sage: perm.stratum_component() == Stratum([5,3,3,3,2], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1564,7 +1564,7 @@ def only_odds_11(even_zeros):
         sage: perm
         0 1 2 3 4 5 6 7
         2 6 4 1 7 5 3 0
-        sage: perm.stratum_component() == AbelianStratum(2,1,1).unique_component()
+        sage: perm.stratum_component() == Stratum([2,1,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1572,7 +1572,7 @@ def only_odds_11(even_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10
         2 4 9 7 3 8 5 1 10 6 0
-        sage: perm.stratum_component() == AbelianStratum(2,2,1,1).unique_component()
+        sage: perm.stratum_component() == Stratum([2,2,1,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1580,7 +1580,7 @@ def only_odds_11(even_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12
         2 6 4 8 7 5 3 9 12 11 1 10 0
-        sage: perm.stratum_component() == AbelianStratum(4,2,1,1).unique_component()
+        sage: perm.stratum_component() == Stratum([4,2,1,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1588,7 +1588,7 @@ def only_odds_11(even_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11
         2 6 4 1 8 7 10 9 11 5 3 0
-        sage: perm.stratum_component() == AbelianStratum(6,1,1).unique_component()
+        sage: perm.stratum_component() == Stratum([6,1,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1596,7 +1596,7 @@ def only_odds_11(even_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12 13 14
         2 7 4 10 9 5 8 6 3 11 14 13 1 12 0
-        sage: perm.stratum_component() == AbelianStratum(4,4,1,1).unique_component()
+        sage: perm.stratum_component() == Stratum([4,4,1,1],k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1604,7 +1604,7 @@ def only_odds_11(even_zeros):
         sage: perm
         0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
         2 7 4 14 9 8 11 10 13 5 12 6 3 15 18 17 20 16 1 19 0
-        sage: perm.stratum_component() == AbelianStratum(8,6,1,1).unique_component()
+        sage: perm.stratum_component() == Stratum([8,6,1,1], k=1).unique_component()
         True
         sage: _cylinder_check(perm)
         True
@@ -1616,7 +1616,7 @@ def only_odds_11(even_zeros):
             return perm
         else:
             even_zeros.remove(2)
-            even_perm = AbelianStratum(even_zeros).odd_component().single_cylinder_representative()
+            even_perm = Stratum(even_zeros, k=1).odd_component().single_cylinder_representative()
             return cylinder_concatenation(perm,even_perm)
     elif set(even_zeros) == {2} and len(even_zeros) % 2 == 0:
         perm = GeneralizedPermutation([0,1,2,3,4,5,6,7,8,9,10],[2,4,9,7,3,8,5,1,10,6,0])
@@ -1625,11 +1625,11 @@ def only_odds_11(even_zeros):
         else:
             even_zeros.remove(2)
             even_zeros.remove(2)
-            even_perm = AbelianStratum(even_zeros).odd_component().single_cylinder_representative()
+            even_perm = Stratum(even_zeros, k=1).odd_component().single_cylinder_representative()
             return cylinder_concatenation(perm,even_perm)
     elif even_zeros.count(2) == 1 and len(even_zeros) == 2:
         perm = GeneralizedPermutation([0,1,2,3,4,5,6,7],[2,6,4,1,7,5,3,0])
-        even_perm = AbelianStratum(even_zeros[0]).odd_component().single_cylinder_representative()
+        even_perm = Stratum([even_zeros[0]], k=1).odd_component().single_cylinder_representative()
         return cylinder_concatenation(perm,even_perm)
     else:
         num = even_zeros[0]
@@ -1643,7 +1643,7 @@ def only_odds_11(even_zeros):
             if len(even_zeros) == 1:
                 return perm
             else:
-                even_perm = AbelianStratum(even_zeros[1:]).odd_component().single_cylinder_representative()
+                even_perm = Stratum(even_zeros[1:], k=1).odd_component().single_cylinder_representative()
                 return cylinder_concatenation(perm,even_perm)
         else:
             if num == 4:
@@ -1658,7 +1658,7 @@ def only_odds_11(even_zeros):
             if len(even_zeros) == 1:
                 return perm
             else:
-                even_perm = AbelianStratum(even_zeros[1:]).odd_component().single_cylinder_representative()
+                even_perm = Stratum(even_zeros[1:], k=1).odd_component().single_cylinder_representative()
                 return cylinder_concatenation(perm,even_perm)
 
 
@@ -1688,19 +1688,19 @@ def cylinder_concatenation(perm_1, perm_2, alphabet=None):
     We first take two single cylinder permutation representatives for the odd
     components of H_3(4)^odd and H_4(6)^odd.::
 
-        sage: perm_1 = AbelianStratum(4).odd_component().single_cylinder_representative()
+        sage: perm_1 = Stratum([4], k=1).odd_component().single_cylinder_representative()
         sage: perm_1
         0 1 2 3 4 5
         2 5 4 1 3 0
-        sage: perm_1.stratum_component() == AbelianStratum(4).odd_component()
+        sage: perm_1.stratum_component() == Stratum([4], k=1).odd_component()
         True
         sage: _cylinder_check(perm_1)
         True
-        sage: perm_2 = AbelianStratum(6).odd_component().single_cylinder_representative()
+        sage: perm_2 = Stratum([6], k=1).odd_component().single_cylinder_representative()
         sage: perm_2
         0 1 2 3 4 5 6 7
         2 5 4 7 3 1 6 0
-        sage: perm_2.stratum_component() == AbelianStratum(6).odd_component()
+        sage: perm_2.stratum_component() == Stratum([6], k=1).odd_component()
         True
         sage: _cylinder_check(perm_2)
         True
@@ -1713,7 +1713,7 @@ def cylinder_concatenation(perm_1, perm_2, alphabet=None):
         sage: perm_3
         0 1 2 3 4 5 6 7 8 9 10 11 12
         2 5 4 6 3 7 10 9 12 8 1 11 0
-        sage: perm_3.stratum_component() == AbelianStratum(6,4).odd_component()
+        sage: perm_3.stratum_component() == Stratum([6,4], k=1).odd_component()
         True
         sage: _cylinder_check(perm_3)
         True
@@ -1723,19 +1723,19 @@ def cylinder_concatenation(perm_1, perm_2, alphabet=None):
     that the resulting permutation is a single cylinder permutation representative
     of the connected component H_6(6,4)^even.::
 
-        sage: perm_4 = AbelianStratum(6).even_component().single_cylinder_representative()
+        sage: perm_4 = Stratum([6], k=1).even_component().single_cylinder_representative()
         sage: perm_5 = cylinder_concatenation(perm_1,perm_4,Alphabet(name='lower'))
         sage: perm_4
         0 1 2 3 4 5 6 7
         2 7 6 5 3 1 4 0
-        sage: perm_4.stratum_component() == AbelianStratum(6).even_component()
+        sage: perm_4.stratum_component() == Stratum([6], k=1).even_component()
         True
         sage: _cylinder_check(perm_4)
         True
         sage: perm_5
         a b c d e f g h i j k l m
         c f e g d h m l k i b j a
-        sage: perm_5.stratum_component() == AbelianStratum(6,4).even_component()
+        sage: perm_5.stratum_component() == Stratum([6,4], k=1).even_component()
         True
         sage: _cylinder_check(perm_5)
         True

--- a/surface_dynamics/flat_surfaces/strata.py
+++ b/surface_dynamics/flat_surfaces/strata.py
@@ -14,11 +14,11 @@ This file gather common code used in
 #                  https://www.gnu.org/licenses/
 #*****************************************************************************
 
-from __future__ import print_function, absolute_import, division
-from six.moves import range, map, filter, zip
+import numbers
 
 from functools import total_ordering
 
+from sage.misc.cachefunc import cached_method
 from sage.structure.unique_representation import UniqueRepresentation
 from sage.structure.sage_object import SageObject
 from sage.structure.parent import Parent
@@ -52,42 +52,409 @@ def list_to_exp_list(l):
 
 class Stratum(UniqueRepresentation, SageObject):
     r"""
-    Generic class for stratum of flat surfaces.
+    Stratum of holomorphic or meromorphic k-differentials on smooth connected Riemann surfaces.
 
-    Assumes there are
+    INPUT:
 
-    - a method ``.zeros()`` which returns the list of all zeros
+    - ``signature`` -- a list of ``n`` integers (determine the angles of
+      conical singularities)
 
-    - a method ``.nb_zeros()`` which returns the number of zeros with an option
-      fake_zeros which could be true or false
+    - ``k`` -- optional integer (default ``1``) the order of the differential
 
-    - a method ``.nb_fake_zeros()`` which returns the number of fake zeros (or
-      marked points)
+    EXAMPLES::
 
-    - a method ``.dimension()`` which returns the dimension of the stratum
-
-    - an attribute ``._cc`` which is a list of classes associated to the
-      connected components of self
-
-    There may be
-
-    - an attribute ``._name`` which corresponds to the beginning of the string
-      representation (default is the empty string)
-
-    - an attribute ``._latex_name`` which corresponds to the beginning of the latex
-      string representation (uses ``_name`` by default)
+        sage: from surface_dynamics import Stratum
+        sage: Stratum((2,), k=1)
+        H_2(2)
 
     TESTS::
 
-            sage: from surface_dynamics import *
-
-            sage: A = AbelianStratum(2,2)
-            sage: B = AbelianStratum(1,1)
-            sage: hash(A) == hash(B)
-            False
+        sage: S = Stratum((2,), k=1)
+        sage: loads(dumps(S)) == S
+        True
+        sage: S = Stratum((2, 2, 2), k=3)
+        sage: loads(dumps(S)) == S
+        True
     """
-    _name = ''
-    _latex_name = ''
+    @staticmethod
+    def __classcall_private__(self, signature, k=1):
+        if not isinstance(k, numbers.Integral) or k <= 0:
+            raise ValueError('k must be a positive integer')
+        k = int(k)
+        if isinstance(signature, dict):
+            signature = sum(([i] * mult for i, mult in signature.items()), [])
+        signature = tuple(signature)
+        if not signature:
+            raise ValueError('the signature must be non-empty')
+        for m in signature:
+            if not isinstance(m, numbers.Integral):
+                raise ValueError('mu must be a list of integers')
+
+        signature = tuple(sorted(map(int, signature), reverse=True))
+        return super().__classcall__(Stratum, signature, k)
+
+    def __new__(cls, signature, k):
+        if k == 1:
+            from .abelian_strata import AbelianStratum as cls
+        elif k == 2:
+            from .quadratic_strata import QuadraticStratum as cls
+        else:
+            cls = Stratum
+        return object.__new__(cls)
+
+    def __init__(self, signature, k=1):
+        s = sum(signature)
+        if s % (2 * k):
+            raise ValueError('the sum of orders must be congruent to 2 k = {} got {} (mu={})'.format(2 * k, s, signature))
+        if s < - 2 * k:
+            raise ValueError('the sum of orders must be at least {} (got {})'.format(- 2 * k, s))
+        self._k = k
+        self._signature = signature
+
+    def __reduce__(self):
+        return Stratum, (self._signature, self._k)
+
+    def surface_differential_order(self):
+        r"""
+        Return the order of differentials in this stratum.
+
+        EXAMPLES::
+
+            sage: from surface_dynamics import Stratum
+            sage: Stratum([1]*6, 3).surface_differential_order()
+            3
+        """
+        return self._k
+
+    # NOTE: called g in diffstrata GeneralisedStratum
+    # the name here might be misleading as this is not the genus of the space but of the object in the moduli
+    def surface_genus(self):
+        r"""
+        Return the genus of the surfaces in this stratum.
+
+        EXAMPLES::
+
+            sage: from surface_dynamics import Stratum
+
+            sage: Stratum((0,), k=1).surface_genus()
+            1
+            sage: Stratum((1,1), k=1).surface_genus()
+            2
+            sage: Stratum((3,2,1), k=1).surface_genus()
+            4
+
+            sage: Stratum((-1,-1,-1,-1), k=2).surface_genus()
+            0
+        """
+        return sum(self._signature) // (2 * self._k) + 1
+
+    def genus(self):
+        import warnings
+
+        warnings.warn('genus() has been deprecated and will be removed in a future version of surface-dynamics; use surface_genus()')
+
+        return self.surface_genus()
+
+    def surface_has_finite_area(self):
+        r"""
+        Return whether the k-differentials in this moduli space have finite or
+        infinite area.
+
+        EXAMPLES::
+
+            sage: from surface_dynamics import Stratum
+            sage: Stratum((3, 2, 1), k=1).surface_has_finite_area()
+            True
+            sage: Stratum((1, 0, -1), k=1).surface_has_finite_area()
+            False
+
+            sage: Stratum([-1]*6, k=3).surface_has_finite_area()
+            True
+            sage: Stratum([-2]*3, k=3).surface_has_finite_area()
+            True
+            sage: Stratum([-3]*2, k=3).surface_has_finite_area()
+            False
+        """
+        return self._signature[-1] > -self._k
+
+    def dimension(self):
+        r"""
+        Return the complex dimension of this stratum.
+
+        The dimension is `2g-2+s+1` where `g` is the genus of surfaces in the
+        stratum, `s` the number of singularities. The complex dimension of a
+        stratum is also the number of intervals of any interval exchange
+        transformations associated to the strata.
+
+        EXAMPLES::
+
+            sage: from surface_dynamics import Stratum
+
+            sage: Stratum((0,), k=1).dimension()
+            2
+            sage: Stratum((0,0), k=1).dimension()
+            3
+            sage: Stratum((2,), k=1).dimension()
+            4
+            sage: Stratum((1,1), k=1).dimension()
+            5
+
+            sage: Stratum({-1:4}, k=2).dimension()
+            2
+
+        ::
+
+            sage: a = Stratum((4,3,2,1,0), k=1)
+            sage: p = a.permutation_representative()
+            sage: len(p) == a.dimension()
+            True
+        """
+        if self._k == 1 and all(x >= 0 for x in self._signature):
+            return 2 * self.surface_genus() + len(self._signature) - 1
+        elif self._k == 2 and all(x >= -1 for x in self._signature):
+            return 2 * self.surface_genus() + len(self._signature) - 2
+
+        raise NotImplementedError
+
+    def rank(self):
+        r"""
+        Return the rank of this GL(2,R)-invariant manifold (half dimension of the
+        absolute part of the tangent space).
+
+        EXAMPLES::
+
+            sage: from surface_dynamics import Stratum, QuadraticStrata
+
+            sage: Stratum((0,0), k=1).rank()
+            1
+            sage: Stratum((2,), k=1).rank()
+            2
+            sage: Stratum((2,0,0), k=1).rank()
+            2
+
+            sage: Stratum({-1: 4}, k=2).rank()
+            1
+            sage: Stratum({-1:4, 0:5}, k=2).rank()
+            1
+
+        Complete list of rank 2 quadratic strata listed by dimension::
+
+            sage: for dim in range(4, 9):
+            ....:     quad = [Q for Q in QuadraticStrata(dimension=dim) if Q.rank() == 2]
+            ....:     print("%d: %s" % (dim, ", ".join(map(str, quad))))
+            4: Q_2(5, -1), Q_1(1^2, -1^2), Q_1(3, -1^3), Q_0(1, -1^5)
+            5: Q_3(8), Q_2(2, 1^2), Q_2(4, 1, -1), Q_2(3, 2, -1), Q_2(6, -1^2), Q_1(2, 1, -1^3), Q_1(4, -1^4), Q_0(2, -1^6)
+            6: Q_3(6, 2), Q_3(4^2), Q_2(2^2, 1, -1), Q_2(4, 2, -1^2), Q_1(2^2, -1^4)
+            7: Q_3(4, 2^2), Q_2(2^3, -1^2)
+            8: Q_3(2^4)
+        """
+        if self._k == 1:
+            if all(x >= 0 for x in self._signature):
+                return self.surface_genus()
+            else:
+                # is there a meaning for rank?
+                raise NotImplementedError
+        elif self._k == 2:
+            if all(x >= -1 for x in self._signature):
+                return self.surface_genus() + sum(z % 2 for z in self._signature) // 2 - 1
+            else:
+                # is there a meaning for rank?
+                raise NotImplementedError
+        elif self._k >= 3:
+            raise ValueError('not a GL(2,R)-invariant manifold')
+
+    def signature(self):
+        r"""
+        Return the order of zeros with multiplicities.
+
+        EXAMPLES::
+
+            sage: from surface_dynamics import Stratum
+
+            sage: Stratum([1, 2, 3], k=1).signature()
+            (3, 2, 1)
+            sage: Stratum({2: 4}, k=1).signature()
+            (2, 2, 2, 2)
+            sage: Stratum([-1, 1], k=1).signature()
+            (1, -1)
+
+            sage: Stratum({-1: 4}, k=2).signature()
+            (-1, -1, -1, -1)
+            sage: Stratum({1: 8}, k=2).signature()
+            (1, 1, 1, 1, 1, 1, 1, 1)
+            sage: Stratum({-2: 2, 0: 1}, k=2).signature()
+            (0, -2, -2)
+        """
+        return self._signature
+
+    def zeros(self, fake_zeros=True, poles=True):
+        import warnings
+
+        warnings.warn('zeros() has been deprecated and will be removed in a future version of surface-dynamics; use signature()')
+        s = self.signature()
+        if not fake_zeros:
+            s = tuple(m for m in s if m)
+        if not poles:
+            s = tuple(m for m in s if m >= 0)
+        return s
+
+    # TODO: this is a terrible name!
+    def nb_zeros(self, fake_zeros=True, poles=True):
+        r"""
+        Returns the number of zeros of self.
+
+        EXAMPLES::
+
+            sage: from surface_dynamics import Stratum
+
+            sage: Stratum([0], k=1).nb_zeros()
+            doctest:warning
+            ...
+            UserWarning: nb_zero() has been deprecated and will be removed in a future version of surface-dynamics; use signature()
+            1
+            sage: Stratum({2:4,3:2}, k=1).nb_zeros()
+            6
+
+            sage: Stratum({-1:4}, k=2).nb_zeros()
+            4
+            sage: Stratum({-1:4,1:4}, k=2).nb_zeros()
+            8
+        """
+        import warnings
+
+        warnings.warn('nb_zero() has been deprecated and will be removed in a future version of surface-dynamics; use signature()')
+
+        return sum(int((fake_zeros or m) and (poles or m >= 0)) for m in self.signature())
+
+    def nb_fake_zeros(self):
+        r"""
+        Return the number of fake zeros.
+
+        EXAMPLES::
+
+            sage: from surface_dynamics import Stratum
+
+            sage: Stratum([0], k=1).nb_fake_zeros()
+            1
+            sage: Stratum([1,1,0,0], k=1).nb_fake_zeros()
+            2
+
+            sage: Stratum([0,4,2,2], k=2).nb_fake_zeros()
+            1
+        """
+        return self._signature.count(0)
+
+    def nb_poles(self):
+        r"""
+        Return the number of poles of this quadratic stratum.
+        """
+        import warnings
+
+        warnings.warn('nb_poles() has been deprecated and will be removed in a future version of surface-dynamics; use signature()')
+
+        return sum(int(m < 0) for m in self.signature())
+
+    @cached_method
+    def connected_components(self):
+        r"""
+        Return the connected components of this stratum of differentials.
+
+        - Abelian holomorphic differentials [KonZor03]_
+        - Quadratic differentials with at most simple poles [Lan08]_
+        """
+        zeros = tuple(m for m in self._signature if m)
+
+        if self._k == 1:
+            if any(m < 0 for m in zeros):
+                raise NotImplementedError('not available for meromorphic differentials')
+
+            # Abelian differentials: Kontsevich-Zorich classification
+            from .abelian_strata import ASC, HypASC, NonHypASC, OddASC, EvenASC
+            s = sum(zeros)
+            genus = s // 2 + 1
+
+            if genus == 1:
+                return (HypASC(self),)
+            elif genus == 2:
+                return (HypASC(self),)
+            elif genus == 3:
+                if zeros == (2, 2) or zeros == (4,):
+                    return (HypASC(self), OddASC(self))
+                else:
+                    return (ASC(self),)
+            elif len(zeros) == 1:
+                    # just one zeros [2g-2]
+                    return (HypASC(self), OddASC(self), EvenASC(self))
+            elif zeros == (genus-1, genus-1):
+                # two identical zeros [g-1, g-1]
+                if genus % 2 == 0:
+                    return (HypASC(self), NonHypASC(self))
+                else:
+                    return (HypASC(self), OddASC(self), EvenASC(self))
+            elif all(x%2 == 0 for x in zeros):
+                # even zeroes [2 l_1, 2 l_2, ..., 2 l_n]
+                return (OddASC(self), EvenASC(self))
+            else:
+                return (ASC(self), ) 
+
+        elif self._k == 2:
+            if any(m < -1 for m in zeros):
+                raise NotImplementedError('not available for meromorphic differential with higher order poles')
+
+            # quadratic differentials: Lanneau classification
+            from .quadratic_strata import CQSC, HQSC, GTNQSC, GTHQSC, GOQSC, REQSC, IEQSC, GZQSC, NQSC
+            nb_poles = zeros.count(-1)
+            s = sum(zeros)
+            genus = s // 4 + 1
+
+            #TODO: check genus 2 components
+            #TODO: in genus 2, decide between GTHQSC/GTNQSC and HQSC/NQSC
+            if genus == 0:
+                return (GZQSC(self),)
+
+            #TODO: all genus 1 strata are connected, but two are hyperelliptic; give the component a different name then?
+            elif genus == 1:
+                if zeros == () or zeros == (1, -1):
+                    # empty!
+                    return ()
+                else:
+                    return  (GOQSC(self),)
+
+            elif genus == 2:
+                if zeros == (4,) or zeros == (3, 1):
+                    # empty!
+                    return ()
+                elif zeros == (6, -1, -1):
+                    return (HQSC(self), GTNQSC(self))
+                elif zeros == (3, 3, -1, -1):
+                    return (HQSC(self), GTNQSC(self))
+                elif zeros == (2, 2) or zeros == (2, 1, 1) or zeros == (1, 1, 1, 1):
+                    return (GTHQSC(self),)
+                else:
+                    return (GTNQSC(self),)
+
+            elif genus == 3 and nb_poles == 1 and all((z == -1 or z % 3 == 0) for z in zeros):
+                return (REQSC(self), IEQSC(self))
+
+            elif genus == 4 and nb_poles == 0 and all(z % 3 == 0 for z in zeros):
+                if zeros == (12,) or zeros == (9, 3):
+                    return (REQSC(self), IEQSC(self))
+                elif zeros == (6, 6) or zeros == (6, 3, 3) or zeros == (3, 3, 3, 3):
+                    return (HQSC(self), REQSC(self), IEQSC(self))
+            else:
+                if len(zeros) == 2 and zeros[0] % 4 == 2 and zeros[1] % 4 == 2:
+                    return (HQSC(self), NQSC(self))
+                elif len(zeros) == 4 and zeros[0] == zeros[1] and zeros[2] == zeros[3] and zeros[0] % 2 and zeros[2] % 2:
+                    return (HQSC(self), NQSC(self))
+                elif len(zeros) == 3 and zeros[0] == zeros[1] and zeros[0] % 2 and zeros[2] % 4 == 2:
+                    return (HQSC(self), NQSC(self))
+                elif len(zeros) == 3 and zeros[1] == zeros[2] and zeros[1] % 2 and zeros[0] % 4 == 2:
+                    return (HQSC(self), NQSC(self))
+                else:
+                    return (CQSC(self),)
+
+        else:
+            raise NotImplementedError('not available for higher order differentials')
 
     #
     # String representation
@@ -99,13 +466,13 @@ class Stratum(UniqueRepresentation, SageObject):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: a = AbelianStratum({2:3})
+            sage: a = Stratum({2:3}, k=1)
             sage: a._flat_zero_str()
             '2, 2, 2'
         """
-        return ', '.join(map(str,self.zeros()))
+        return ', '.join(map(str, self.signature()))
 
     def _exp_zero_str(self):
         r"""
@@ -113,13 +480,13 @@ class Stratum(UniqueRepresentation, SageObject):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: a = AbelianStratum(2,2,2)
+            sage: a = Stratum({2: 3}, k=1)
             sage: a._exp_zero_str()
             '2^3'
         """
-        return ', '.join('%d^%d' %(i,e) if e != 1 else '%d' %i for (i,e) in list_to_exp_list(self.zeros()))
+        return ', '.join('%d^%d' %(i,e) if e != 1 else '%d' %i for (i,e) in list_to_exp_list(self.signature()))
 
     # this attribute can be switched between _flat_zero_str and _exp_zero_str
     _zero_str = _exp_zero_str
@@ -128,14 +495,24 @@ class Stratum(UniqueRepresentation, SageObject):
         """
         TESTS::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: repr(AbelianStratum(1,1))       # indirect doctest
+            sage: repr(Stratum([1,1], k=1))       # indirect doctest
             'H_2(1^2)'
-            sage: repr(QuadraticStratum(1,1,1,1)) # indirect doctest
+            sage: repr(Stratum([1,1,1,1], k=2)) # indirect doctest
             'Q_2(1^4)'
         """
-        return self._name + "_" + str(self.genus()) + "(" + self._zero_str() + ")"
+        try:
+            name = self._name
+        except AttributeError:
+            if self._k == 1:
+                name = 'H'
+            elif self._k == 2:
+                name = 'Q'
+            else:
+                name = 'H^{{({})}}'.format(self._k)
+
+        return name + "_" + str(self.surface_genus()) + "(" + self._zero_str() + ")"
 
     def _latex_(self):
         r"""
@@ -143,14 +520,14 @@ class Stratum(UniqueRepresentation, SageObject):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: AbelianStratum(0)._latex_()
+            sage: Stratum([0], k=1)._latex_()
             '\\mathcal{H}_1(0)'
-            sage: QuadraticStratum({-1:4})._latex_()
+            sage: Stratum({-1:4}, k=2)._latex_()
             '\\mathcal{Q}_0(-1^4)'
         """
-        return self._latex_name + '_' + str(self.genus()) + "(" + self._zero_str() + ")"
+        return self._latex_name + '_' + str(self.surface_genus()) + "(" + self._zero_str() + ")"
 
     #
     # Equality and comparisons
@@ -166,53 +543,53 @@ class Stratum(UniqueRepresentation, SageObject):
 
         TESTS::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: AbelianStratum(0) == AbelianStratum(0)
+            sage: Stratum([0], k=1) == Stratum([0], k=1)
             True
-            sage: QuadraticStratum(5,-1) == QuadraticStratum(5,-1)
+            sage: Stratum([5,-1], k=2) == Stratum([5,-1], k=2)
             True
-            sage: QuadraticStratum(5,-1) != QuadraticStratum(5,-1)
-            False
-
-            sage: AbelianStratum(12) == QuadraticStratum(12)
-            False
-            sage: QuadraticStratum(12,0,0) == QuadraticStratum(12,0)
+            sage: Stratum([5,-1], k=2) != Stratum([5,-1], k=2)
             False
 
-            sage: AbelianStratum(2,0) == AbelianStratum(2)
+            sage: Stratum([12], k=1) == Stratum([12], k=2)
             False
-            sage: AbelianStratum(2,0) != AbelianStratum(2)
+            sage: Stratum([12,0,0], k=2) == Stratum([12,0], k=2)
+            False
+
+            sage: Stratum([2,0], k=1) == Stratum([2], k=1)
+            False
+            sage: Stratum([2,0], k=1) != Stratum([2], k=1)
             True
 
-            sage: AbelianStratum(1,1) < AbelianStratum(1,1,0)
+            sage: Stratum([1,1], k=1) < Stratum([1,1,0], k=1)
             True
-            sage: AbelianStratum(1,1,0) < AbelianStratum(1,1)
+            sage: Stratum([1,1,0], k=1) < Stratum([1,1], k=1)
             False
-            sage: AbelianStratum(1,1,0) < AbelianStratum(1,1,0,0)
+            sage: Stratum([1,1,0], k=1) < Stratum([1,1,0,0], k=1)
             True
-            sage: AbelianStratum(2) < AbelianStratum(1,1)
+            sage: Stratum([2], k=1) < Stratum([1,1], k=1)
             True
-            sage: AbelianStratum(4,0) > AbelianStratum(1,1,1,1)
+            sage: Stratum([4,0], k=1) > Stratum([1,1,1,1], k=1)
             False
-            sage: AbelianStratum(4,0,0,0) > AbelianStratum(1,1,1,1)
+            sage: Stratum([4,0,0,0], k=1) > Stratum([1,1,1,1], k=1)
             True
 
         ::
 
-            sage: QuadraticStratum(2,2) < QuadraticStratum(2,2,0)
+            sage: Stratum([2,2], k=2) < Stratum([2,2,0], k=2)
             True
-            sage: QuadraticStratum(2,2,0) < QuadraticStratum(2,2)
+            sage: Stratum([2,2,0], k=2) < Stratum([2,2], k=2)
             False
-            sage: QuadraticStratum(2,2,0) < QuadraticStratum(2,2,0,0)
+            sage: Stratum([2,2,0], k=2) < Stratum([2,2,0,0], k=2)
             True
-            sage: QuadraticStratum(4) < QuadraticStratum(2,2)
+            sage: Stratum([4], k=2) < Stratum([2,2], k=2)
             True
-            sage: QuadraticStratum(4,0) > QuadraticStratum(1,1,1,1)
+            sage: Stratum([4,0], k=2) > Stratum([1,1,1,1], k=2)
             False
 
-            sage: Q1 = QuadraticStratum(4,0,0,0)
-            sage: Q2 = QuadraticStratum(1,1,1,1)
+            sage: Q1 = Stratum([4,0,0,0], k=2)
+            sage: Q2 = Stratum([1,1,1,1], k=2)
             sage: Q1 > Q2
             True
             sage: Q1 >= Q2
@@ -225,7 +602,7 @@ class Stratum(UniqueRepresentation, SageObject):
         if not isinstance(self, Stratum) or not isinstance(other, Stratum):
             raise TypeError
 
-        if type(self) is type(other):
+        if self._k == other._k:
             # compare the dimension
             if self.dimension() < other.dimension():
                 return True
@@ -233,23 +610,16 @@ class Stratum(UniqueRepresentation, SageObject):
                 return False
 
             # compare the list of zeros
-            if self.zeros() < other.zeros():
+            if self.signature() < other.signature():
                 return True
-            elif self.zeros() > other.zeros():
+            elif self.signature() > other.signature():
                 return False
 
             # equality
             return False
 
         else:
-            sname = type(self).__name__
-            oname = type(other).__name__
-            if sname < oname:
-                return True
-            elif sname > oname:
-                return False
-
-            return False
+            return self._k < other._k
 
     def __ne__(self, other):
         return not self == other
@@ -273,45 +643,48 @@ class Stratum(UniqueRepresentation, SageObject):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: AbelianStratum([2]).is_connected()
+            sage: Stratum([2], k=1).is_connected()
             True
-            sage: AbelianStratum([2,2]).is_connected()
+            sage: Stratum([2,2], k=1).is_connected()
             False
-            sage: QuadraticStratum([-1,-1,-1,-1]).is_connected()
+
+            sage: Stratum([-1,-1,-1,-1], k=2).is_connected()
             True
-            sage: QuadraticStratum([12]).is_connected()
+            sage: Stratum([12], k=2).is_connected()
             False
         """
-        return len(self._cc) <= 1
+        return len(self.connected_components()) <= 1
 
     def permutation_representative(self, *args, **kwds):
         r"""
         Return a permutation of interval exchanges associated to this stratum.
 
+        This method only makes sense for Abelian and quadratic differentials.
+
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
         Examples from Abelian differentials::
 
-            sage: a = AbelianStratum([3,2,1,0,0])
+            sage: a = Stratum([3,2,1,0,0], k=1)
             sage: p = a.permutation_representative()
             sage: p.stratum()
             H_4(3, 2, 1, 0^2)
-            sage: a = AbelianStratum([2, 2, 2])
+            sage: a = Stratum([2, 2, 2], k=1)
             sage: p = a.permutation_representative()
             sage: p.stratum()
             H_4(2^3)
 
         Examples from quadratic differentials::
 
-            sage: a = QuadraticStratum([6,-1,-1])
+            sage: a = Stratum([6,-1,-1], k=2)
             sage: p = a.permutation_representative()
             sage: p.stratum()
             Q_2(6, -1^2)
-            sage: a = QuadraticStratum([-1,-1,-1,-1,0,0])
+            sage: a = Stratum([-1,-1,-1,-1,0,0], k=2)
             sage: p = a.permutation_representative()
             sage: p.stratum()
             Q_0(0^2, -1^4)
@@ -324,14 +697,14 @@ class Stratum(UniqueRepresentation, SageObject):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: AbelianStratum(2).is_empty()
+            sage: Stratum([2], k=1).is_empty()
             False
-            sage: QuadraticStratum(1,-1).is_empty()
+            sage: Stratum([1,-1], k=2).is_empty()
             True
         """
-        return len(self._cc) == 0
+        return len(self.connected_components()) == 0
 
     def number_of_components(self):
         r"""
@@ -339,16 +712,16 @@ class Stratum(UniqueRepresentation, SageObject):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: AbelianStratum(2).number_of_components()
+            sage: Stratum([2], k=1).number_of_components()
             1
-            sage: AbelianStratum(4).number_of_components()
+            sage: Stratum([4], k=1).number_of_components()
             2
-            sage: AbelianStratum(3,3).number_of_components()
+            sage: Stratum([3,3], k=1).number_of_components()
             2
         """
-        return len(self._cc)
+        return len(self.connected_components())
 
     def one_component(self):
         r"""
@@ -356,9 +729,9 @@ class Stratum(UniqueRepresentation, SageObject):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: AbelianStratum(2).one_component()
+            sage: Stratum([2], k=1).one_component()
             H_2(2)^hyp
         """
         if self.components():
@@ -372,31 +745,34 @@ class Stratum(UniqueRepresentation, SageObject):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: a = AbelianStratum(1,1); a
+            sage: a = Stratum([1,1], k=1)
+            sage: a
             H_2(1^2)
             sage: a.unique_component()
             H_2(1^2)^hyp
 
-            sage: a = AbelianStratum(3,2,1); a
+            sage: a = Stratum([3,2,1], k=1)
+            sage: a
             H_4(3, 2, 1)
             sage: a.unique_component()
             H_4(3, 2, 1)^c
 
-            sage: QuadraticStratum({1:1, -1:5}).unique_component()
+            sage: Stratum({1:1, -1:5}, k=2).unique_component()
             Q_0(1, -1^5)^c
-            sage: QuadraticStratum(3,2,-1).unique_component()
+            sage: Stratum([3,2,-1], k=2).unique_component()
             Q_2(3, 2, -1)^nonhyp
 
-            sage: QuadraticStratum(12).unique_component()
+            sage: Stratum([12], k=2).unique_component()
             Traceback (most recent call last):
             ...
             ValueError: several components for this stratum
         """
-        if len(self._cc) != 1:
+        ccs = self.connected_components()
+        if len(ccs) != 1:
             raise ValueError("several components for this stratum")
-        return self._cc[0](self)
+        return ccs[0]
 
     def random_component(self):
         r"""
@@ -404,9 +780,9 @@ class Stratum(UniqueRepresentation, SageObject):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: Q = QuadraticStratum(6,6)
+            sage: Q = Stratum([6,6], k=2)
             sage: Q.random_component() # random
             Q_4(6^2)^hyp
             sage: Q.random_component() # random
@@ -428,29 +804,30 @@ class Stratum(UniqueRepresentation, SageObject):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
         Some abelian strata::
 
-            sage: AbelianStratum(0).components()
-            [H_1(0)^hyp]
-            sage: AbelianStratum(2).components()
-            [H_2(2)^hyp]
-            sage: AbelianStratum(4).components()
-            [H_3(4)^hyp, H_3(4)^odd]
-            sage: AbelianStratum(2,2).components()
-            [H_3(2^2)^hyp, H_3(2^2)^odd]
-            sage: AbelianStratum(1,1,1,1).components()
-            [H_3(1^4)^c]
+            sage: Stratum([0], k=1).components()
+            (H_1(0)^hyp,)
+            sage: Stratum([2], k=1).components()
+            (H_2(2)^hyp,)
+            sage: Stratum([4], k=1).components()
+            (H_3(4)^hyp, H_3(4)^odd)
+            sage: Stratum([2,2], k=1).components()
+            (H_3(2^2)^hyp, H_3(2^2)^odd)
+            sage: Stratum([1,1,1,1], k=1).components()
+            (H_3(1^4)^c,)
 
         Some quadratic strata::
 
-            sage: QuadraticStratum(12).components()
-            [Q_4(12)^reg, Q_4(12)^irr]
-            sage: QuadraticStratum(6,-1,-1).components()
-            [Q_2(6, -1^2)^hyp, Q_2(6, -1^2)^nonhyp]
+            sage: Stratum([12], k=2).components()
+            (Q_4(12)^reg, Q_4(12)^irr)
+            sage: Stratum([6,-1,-1], k=2).components()
+            (Q_2(6, -1^2)^hyp, Q_2(6, -1^2)^nonhyp)
         """
-        return list(map(lambda x: x(self), self._cc))
+        # TODO: deprecate
+        return self.connected_components()
 
     def masur_veech_volume(self, rational=False, method=None):
         r"""
@@ -466,13 +843,13 @@ class Stratum(UniqueRepresentation, SageObject):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import AbelianStratum
+            sage: from surface_dynamics import Stratum
 
-            sage: AbelianStratum(2).masur_veech_volume()
+            sage: Stratum([2], k=1).masur_veech_volume()
             1/120*pi^4
-            sage: AbelianStratum(1,1,1,1).masur_veech_volume()
+            sage: Stratum([1,1,1,1], k=1).masur_veech_volume()
             1/4860*pi^6
-            sage: AbelianStratum(20).masur_veech_volume()
+            sage: Stratum([20], k=1).masur_veech_volume()
             1604064377302075061983/792184445986404135075840000000000*pi^22
         """
         from .masur_veech_volumes import masur_veech_volume
@@ -500,12 +877,12 @@ class StratumComponent(SageObject):
         r"""
         TESTS::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: a = AbelianStratum(4,4).one_component()
+            sage: a = Stratum([4,4], k=1).one_component()
             sage: a == loads(dumps(a))
             True
-            sage: q = QuadraticStratum(5,5,-1,-1).one_component()
+            sage: q = Stratum([5,5,-1,-1], k=2).one_component()
             sage: q == loads(dumps(q))
             True
         """
@@ -517,33 +894,33 @@ class StratumComponent(SageObject):
 
         TESTS::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
         Tests for Abelian strata::
 
-            sage: a = AbelianStratum(2,2)
+            sage: a = Stratum([2,2], k=1)
             sage: all(loads(dumps(cc)) == cc for cc in a.components())
             True
-            sage: a = AbelianStratum(3,3)
+            sage: a = Stratum([3,3], k=1)
             sage: all(loads(dumps(cc)) == cc for cc in a.components())
             True
-            sage: a = AbelianStratum(6)
+            sage: a = Stratum([6], k=1)
             sage: all(loads(dumps(cc)) == cc for cc in a.components())
             True
-            sage: a = AbelianStratum(1,1,1,1)
+            sage: a = Stratum([1,1,1,1], k=1)
             sage: all(loads(dumps(cc)) == cc for cc in a.components())
             True
 
         Tests for quadratic strata::
 
-            sage: q = QuadraticStratum(-1,-1,-1,-1)
+            sage: q = Stratum([-1,-1,-1,-1], k=2)
             sage: all(loads(dumps(cc)) == cc for cc in q.components())
             True
-            sage: q = QuadraticStratum(12)
+            sage: q = Stratum([12], k=2)
             sage: all(loads(dumps(cc)) == cc for cc in q.components())
             True
         """
-        return (self.__class__, (self._stratum,))
+        return self.__class__, (self._stratum,)
 
     def _repr_(self):
         r"""
@@ -551,12 +928,12 @@ class StratumComponent(SageObject):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: a_hyp = AbelianStratum(4).hyperelliptic_component()
+            sage: a_hyp = Stratum([4], k=1).hyperelliptic_component()
             sage: a_hyp._repr_()
             'H_3(4)^hyp'
-            sage: a_odd = AbelianStratum(4).odd_component()
+            sage: a_odd = Stratum([4], k=1).odd_component()
             sage: a_odd._repr_()
             'H_3(4)^odd'
         """
@@ -566,13 +943,13 @@ class StratumComponent(SageObject):
         r"""
         TESTS::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: A4hyp = AbelianStratum(4).hyperelliptic_component()
-            sage: A4odd = AbelianStratum(4).odd_component()
+            sage: A4hyp = Stratum([4], k=1).hyperelliptic_component()
+            sage: A4odd = Stratum([4], k=1).odd_component()
             sage: hash(A4hyp) != hash(A4odd)
             True
-            sage: A22hyp = AbelianStratum(2,2).hyperelliptic_component()
+            sage: A22hyp = Stratum([2,2], k=1).hyperelliptic_component()
             sage: hash(A22hyp) != hash(A4hyp)
             True
         """
@@ -584,27 +961,34 @@ class StratumComponent(SageObject):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: a = AbelianStratum(4,4)
+            sage: a = Stratum([4,4], k=1)
             sage: all([c.stratum() == a for c in a.components()])
             True
         """
         return self._stratum
 
-    def genus(self):
+    def surface_genus(self):
         r"""
         Return genus of the corresponding stratum
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: a = AbelianStratum(4,4)
-            sage: a.one_component().genus()
+            sage: a = Stratum([4,4], k=1)
+            sage: a.one_component().surface_genus()
             5
         """
-        return self._stratum.genus()
+        return self._stratum.surface_genus()
+
+    def genus(self):
+        import warnings
+
+        warnings.warn('genus() has been deprecated and will be removed in a future version of surface-dynamics; use surface_genus()')
+
+        return self.surface_genus()
 
     def dimension(self):
         r"""
@@ -612,11 +996,11 @@ class StratumComponent(SageObject):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import AbelianStratum, QuadraticStratum
+            sage: from surface_dynamics import Stratum
 
-            sage: AbelianStratum(4).odd_component().dimension()
+            sage: Stratum([4], k=1).odd_component().dimension()
             6
-            sage: QuadraticStratum(12).regular_component().dimension()
+            sage: Stratum([12], k=2).regular_component().dimension()
             7
         """
         return self._stratum.dimension()
@@ -627,11 +1011,11 @@ class StratumComponent(SageObject):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import AbelianStratum, QuadraticStratum
+            sage: from surface_dynamics import Stratum
 
-            sage: AbelianStratum(4).odd_component().rank()
+            sage: Stratum([4], k=1).odd_component().rank()
             3
-            sage: QuadraticStratum(12).regular_component().rank()
+            sage: Stratum([12], k=2).regular_component().rank()
             3
         """
         return self._stratum.rank()
@@ -642,10 +1026,10 @@ class StratumComponent(SageObject):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: c_hyp = AbelianStratum(6).hyperelliptic_component()
-            sage: c_odd = AbelianStratum(6).odd_component()
+            sage: c_hyp = Stratum([6], k=1).hyperelliptic_component()
+            sage: c_odd = Stratum([6], k=1).odd_component()
             sage: c_hyp == c_hyp
             True
             sage: c_hyp == c_odd
@@ -662,19 +1046,19 @@ class StratumComponent(SageObject):
 
         TESTS::
 
-            sage: from surface_dynamics import *
+            sage: from surface_dynamics import Stratum
 
-            sage: a1 = AbelianStratum(1,1,1,1)
+            sage: a1 = Stratum([1,1,1,1], k=1)
             sage: c1 = a1.components()[0]
-            sage: a2 = AbelianStratum(3,1)
+            sage: a2 = Stratum([3,1], k=1)
             sage: c2 = a2.components()[0]
             sage: c1 == c1
             True
             sage: c1 == c2
             False
-            sage: a1 = AbelianStratum(1,1,1,1)
+            sage: a1 = Stratum([1,1,1,1], k=1)
             sage: c1 = a1.components()[0]
-            sage: a2 = AbelianStratum(2, 2)
+            sage: a2 = Stratum([2, 2], k=1)
             sage: c2_hyp, c2_odd = a2.components()
             sage: c1 != c1
             False
@@ -710,11 +1094,11 @@ class StratumComponent(SageObject):
 
         EXAMPLES::
 
-            sage: from surface_dynamics import AbelianStratum
+            sage: from surface_dynamics import Stratum
 
-            sage: AbelianStratum(4).hyperelliptic_component().masur_veech_volume()
+            sage: Stratum([4], k=1).hyperelliptic_component().masur_veech_volume()
             1/6720*pi^6
-            sage: AbelianStratum(6).even_component().masur_veech_volume()
+            sage: Stratum([6], k=1).even_component().masur_veech_volume()
             32/1913625*pi^8
         """
         from .masur_veech_volumes import masur_veech_volume

--- a/surface_dynamics/flat_surfaces/strata.py
+++ b/surface_dynamics/flat_surfaces/strata.py
@@ -291,6 +291,7 @@ class Stratum(UniqueRepresentation, SageObject):
         import warnings
 
         warnings.warn('zeros() has been deprecated and will be removed in a future version of surface-dynamics; use signature()')
+
         s = self.signature()
         if not fake_zeros:
             s = tuple(m for m in s if m)
@@ -371,7 +372,7 @@ class Stratum(UniqueRepresentation, SageObject):
         zeros = tuple(m for m in self._signature if m)
 
         if not self.surface_has_finite_area():
-            raise NotImplementedError('meromorphic differentials with higher oder poles')
+            raise NotImplementedError('meromorphic differentials with higher order poles')
 
         if self._k == 1:
             # Abelian differentials: Kontsevich-Zorich classification

--- a/surface_dynamics/flat_surfaces/strata.py
+++ b/surface_dynamics/flat_surfaces/strata.py
@@ -395,7 +395,7 @@ class Stratum(UniqueRepresentation, SageObject):
                 # even zeroes [2 l_1, 2 l_2, ..., 2 l_n]
                 return (OddASC(self), EvenASC(self))
             else:
-                return (ASC(self), ) 
+                return (ASC(self),)
 
         elif self._k == 2:
             if any(m < -1 for m in zeros):

--- a/surface_dynamics/flat_surfaces/twist_space.py
+++ b/surface_dynamics/flat_surfaces/twist_space.py
@@ -132,9 +132,9 @@ class TwistSpace:
 
         EXAMPLES::
 
-            sage: from surface_dynamics import AbelianStratum
+            sage: from surface_dynamics import Stratum
             sage: from surface_dynamics.flat_surfaces.twist_space import TwistSpace
-            sage: for cd in AbelianStratum(1,1,1,1).cylinder_diagrams(2):
+            sage: for cd in Stratum([1,1,1,1], k=1).cylinder_diagrams(2):
             ....:     hom_cyls = TwistSpace(cd).homologous_cylinders()
             ....:     if hom_cyls:
             ....:         print(cd)
@@ -162,9 +162,9 @@ class TwistSpace:
 
         EXAMPLES::
 
-            sage: from surface_dynamics import AbelianStratum
+            sage: from surface_dynamics import Stratum
             sage: from surface_dynamics.flat_surfaces.twist_space import TwistSpace
-            sage: for cd in AbelianStratum(1,1,1,1).cylinder_diagrams():
+            sage: for cd in Stratum([1,1,1,1], k=1).cylinder_diagrams():
             ....:     assert TwistSpace(cd).cylinder_dimension() == cd.homological_dimension_of_cylinders()
         """
         return matrix(list(self.cylinder_core_curves())).rank()

--- a/surface_dynamics/interval_exchanges/cover.py
+++ b/surface_dynamics/interval_exchanges/cover.py
@@ -281,7 +281,7 @@ class PermutationCover(object):
 
             sage: from surface_dynamics import *
 
-            sage: p = QuadraticStratum([1,1,-1,-1]).components()[0].permutation_representative()
+            sage: p = Stratum([1,1,-1,-1], k=2).components()[0].permutation_representative()
             sage: pc = p.orientation_cover()
             sage: pc
             Covering of degree 2 of the permutation:
@@ -306,7 +306,7 @@ class PermutationCover(object):
 
             sage: from surface_dynamics import *
 
-            sage: p = QuadraticStratum([1,1,-1,-1]).components()[0].permutation_representative()
+            sage: p = Stratum([1,1,-1,-1], k=2).components()[0].permutation_representative()
             sage: pc = p.orientation_cover()
             sage: pc
             Covering of degree 2 of the permutation:
@@ -688,12 +688,12 @@ class PermutationCover(object):
         Z = [x-2 for x in self.profile() if fake_zeros or x != 2]
         if not Z:
             Z = [0]
+
+        from surface_dynamics.flat_surfaces.abelian_strata import Stratum
         if self.is_orientable():
-            from surface_dynamics.flat_surfaces.abelian_strata import AbelianStratum
-            return AbelianStratum([z//2 for z in Z])
+            return Stratum([z//2 for z in Z], k=1)
         else:
-            from surface_dynamics.flat_surfaces.quadratic_strata import QuadraticStratum
-            return QuadraticStratum(Z)
+            return Stratum(Z, k=2)
 
     def genus(self):
         r"""
@@ -711,11 +711,11 @@ class PermutationCover(object):
         TESTS::
 
             sage: from surface_dynamics import *
-            sage: o = AbelianStratum([1,2,3,4]).one_component().one_origami()
-            sage: assert(o.genus() == AbelianStratum([1,2,3,4]).genus())
-            sage: qc = QuadraticStratum([1,2,3,4,-1,-1]).one_component()
+            sage: o = Stratum([1,2,3,4], k=1).one_component().one_origami()
+            sage: assert(o.genus() == Stratum([1,2,3,4], k=1).surface_genus())
+            sage: qc = Stratum([1,2,3,4,-1,-1], k=2).one_component()
             sage: p = qc.permutation_representative()
-            sage: assert(p.orientation_cover().genus() == qc.orientation_cover_component().genus())
+            sage: assert(p.orientation_cover().genus() == qc.orientation_cover_component().surface_genus())
         """
         p = self.profile()
         return Integer((sum(p)-2*len(p))/4+1)
@@ -1048,7 +1048,7 @@ class PermutationCover(object):
 
             sage: from surface_dynamics import *
 
-            sage: q = QuadraticStratum([1,1,-1,-1]).one_component()
+            sage: q = Stratum([1,1,-1,-1], k=2).one_component()
             sage: q.lyapunov_exponents_H_plus(nb_iterations=2**19)  # abs tol 0.1
             [0.666666]
             sage: p = q.permutation_representative(reduced=False).orientation_cover()

--- a/surface_dynamics/interval_exchanges/cover.py
+++ b/surface_dynamics/interval_exchanges/cover.py
@@ -1227,9 +1227,11 @@ class PermutationCover(object):
 
             sage: p = iet.Permutation('a b c', 'c b a').cover(['(1,2)','(1,3)','(1,4)'])
             sage: S = p.masur_polygon([1,4,2], [2,0,-1])  # optional: sage_flatsurf
-            sage: S.stratum()                             # optional: sage_flatsurf
+            sage: stratum = S.stratum()                   # optional: sage_flatsurf # random
+            sage: stratum                                 # optional: sage_flatsurf
             H_4(3^2)
-            sage: p.stratum()                             # optional: sage_flatsurf
+            sage: stratum = p.stratum()                   # optional: sage_flatsurf # random
+            sage: stratum                                 # optional: sage_flatsurf
             H_4(3^2)
         """
         base_ring, triangles, tops, bots, mids = self._base._masur_polygon_helper(lengths, heights)

--- a/surface_dynamics/interval_exchanges/labelled.py
+++ b/surface_dynamics/interval_exchanges/labelled.py
@@ -1038,12 +1038,12 @@ class LabelledPermutationLI(LabelledPermutation, OrientablePermutationLI):
         EXAMPLES::
 
             sage: from surface_dynamics import *
-            sage: Q = QuadraticStratum([1,1,-1,-1]).unique_component()
+            sage: Q = Stratum([1,1,-1,-1], k=2).unique_component()
             sage: p = Q.permutation_representative(reduced=False)
             sage: p.lyapunov_exponents_H_plus(nb_iterations=2**20)  # abs tol .1
             [0.6666]
 
-            sage: Q_reg = QuadraticStratum([12]).regular_component()
+            sage: Q_reg = Stratum([12], k=2).regular_component()
             sage: p_reg = Q_reg.permutation_representative(reduced=False)
             sage: lexp = p_reg.lyapunov_exponents_H_plus(nb_iterations=2**20)
             sage: lexp  # random
@@ -1053,7 +1053,7 @@ class LabelledPermutationLI(LabelledPermutation, OrientablePermutationLI):
             sage: sum(lexp)  # abs tol .1
             1.428
 
-            sage: Q_irr = QuadraticStratum([12]).irregular_component()
+            sage: Q_irr = Stratum([12], k=2).irregular_component()
             sage: p_irr = Q_irr.permutation_representative(reduced=False)
             sage: lexp = p_irr.lyapunov_exponents_H_plus(nb_iterations=2**20)
             sage: lexp  # random
@@ -1106,7 +1106,7 @@ class LabelledPermutationLI(LabelledPermutation, OrientablePermutationLI):
         EXAMPLES::
 
             sage: from surface_dynamics import *
-            sage: Q = QuadraticStratum([1,1,-1,-1]).unique_component()
+            sage: Q = Stratum([1,1,-1,-1], k=2).unique_component()
             sage: p = Q.permutation_representative(reduced=False)
             sage: lexp = p.lyapunov_exponents_H_minus(nb_iterations=2**20)
             sage: lexp  # random
@@ -1116,7 +1116,7 @@ class LabelledPermutationLI(LabelledPermutation, OrientablePermutationLI):
             sage: sum(lexp)  # abs tol .1
             1.333
 
-            sage: Q_reg = QuadraticStratum([12]).regular_component()
+            sage: Q_reg = Stratum([12], k=2).regular_component()
             sage: p_reg = Q_reg.permutation_representative(reduced=False)
             sage: lexp = p_reg.lyapunov_exponents_H_minus(nb_iterations=2**19)
             sage: lexp  # random
@@ -1126,7 +1126,7 @@ class LabelledPermutationLI(LabelledPermutation, OrientablePermutationLI):
             sage: sum(lexp)  # abs tol .1
             1.428
 
-            sage: Q_irr = QuadraticStratum([12]).irregular_component()
+            sage: Q_irr = Stratum([12], k=2).irregular_component()
             sage: p_irr = Q_irr.permutation_representative(reduced=False)
             sage: lexp = p_irr.lyapunov_exponents_H_minus(nb_iterations=2**19)
             sage: lexp  # random

--- a/surface_dynamics/interval_exchanges/rauzy_class_cardinality.py
+++ b/surface_dynamics/interval_exchanges/rauzy_class_cardinality.py
@@ -370,22 +370,22 @@ def gamma_std(profile, marking=None):
 
     The Rauzy classes associated to connected strata in genus 3::
 
-        sage: from surface_dynamics import AbelianStratum
-        sage: cc = AbelianStratum(1,1,1,1).unique_component()
+        sage: from surface_dynamics import Stratum
+        sage: cc = Stratum([1,1,1,1], k=1).unique_component()
         sage: d = cc.rauzy_diagram()
         sage: d
         Rauzy diagram with 1255 permutations
         sage: sum(1 for _ in filter(lambda x: x.is_standard(), d)) == rcc.gamma_std([2,2,2,2])
         True
 
-        sage: cc = AbelianStratum(2,1,1).unique_component()
+        sage: cc = Stratum([2,1,1], k=1).unique_component()
         sage: d = cc.rauzy_diagram()
         sage: d
         Rauzy diagram with 2177 permutations
         sage: sum(1 for _ in filter(lambda x: x.is_standard(), d)) == rcc.gamma_std([3,2,2])
         True
 
-        sage: cc = AbelianStratum(3,1).unique_component()
+        sage: cc = Stratum([3,1], k=1).unique_component()
         sage: d = cc.rauzy_diagram()
         sage: d
         Rauzy diagram with 770 permutations
@@ -394,8 +394,8 @@ def gamma_std(profile, marking=None):
 
     The non connected strata in genus 3::
 
-        sage: cc_odd = AbelianStratum(2,2).odd_component()
-        sage: cc_hyp = AbelianStratum(2,2).hyperelliptic_component()
+        sage: cc_odd = Stratum([2,2], k=1).odd_component()
+        sage: cc_hyp = Stratum([2,2], k=1).hyperelliptic_component()
         sage: d_odd = cc_odd.rauzy_diagram()
         sage: d_hyp = cc_hyp.rauzy_diagram()
         sage: d_odd
@@ -407,8 +407,8 @@ def gamma_std(profile, marking=None):
         sage: n_odd + n_hyp == rcc.gamma_std([3,3])
         True
 
-        sage: cc_odd = AbelianStratum(4).odd_component()
-        sage: cc_hyp = AbelianStratum(4).hyperelliptic_component()
+        sage: cc_odd = Stratum([4], k=1).odd_component()
+        sage: cc_hyp = Stratum([4], k=1).hyperelliptic_component()
         sage: d_odd = cc_odd.rauzy_diagram()
         sage: d_hyp = cc_hyp.rauzy_diagram()
         sage: d_odd
@@ -516,9 +516,9 @@ def delta_std(profile, marking=None):
     Non connected strata in genus 3 has two connected components distinguished
     by their spin parity::
 
-        sage: from surface_dynamics import AbelianStratum
-        sage: cc_odd = AbelianStratum(2,2).odd_component()
-        sage: cc_hyp = AbelianStratum(2,2).hyperelliptic_component()
+        sage: from surface_dynamics import Stratum
+        sage: cc_odd = Stratum([2,2], k=1).odd_component()
+        sage: cc_hyp = Stratum([2,2], k=1).hyperelliptic_component()
         sage: d_odd = cc_odd.rauzy_diagram()
         sage: d_hyp = cc_hyp.rauzy_diagram()
         sage: d_odd
@@ -530,8 +530,8 @@ def delta_std(profile, marking=None):
         sage: n_odd - n_hyp == rcc.delta_std([3,3])
         True
 
-        sage: cc_odd = AbelianStratum(4).odd_component()
-        sage: cc_hyp = AbelianStratum(4).hyperelliptic_component()
+        sage: cc_odd = Stratum([4], k=1).odd_component()
+        sage: cc_hyp = Stratum([4], k=1).hyperelliptic_component()
         sage: d_odd = cc_odd.rauzy_diagram()
         sage: d_hyp = cc_hyp.rauzy_diagram()
         sage: d_odd
@@ -672,21 +672,21 @@ def gamma_irr(profile=None, marking=None):
 
     The connected strata in genus 3::
 
-        sage: from surface_dynamics import AbelianStratum
+        sage: from surface_dynamics import Stratum
 
-        sage: c = AbelianStratum(1,1,1,1).unique_component()
+        sage: c = Stratum([1,1,1,1], k=1).unique_component()
         sage: c.rauzy_diagram()
         Rauzy diagram with 1255 permutations
         sage: rcc.gamma_irr([2,2,2,2])
         1255
 
-        sage: c = AbelianStratum(2,1,1).unique_component()
+        sage: c = Stratum([2,1,1], k=1).unique_component()
         sage: c.rauzy_diagram()
         Rauzy diagram with 2177 permutations
         sage: rcc.gamma_irr([3,2,2])
         2177
 
-        sage: c = AbelianStratum(3,1).unique_component()
+        sage: c = Stratum([3,1], k=1).unique_component()
         sage: c.rauzy_diagram()
         Rauzy diagram with 770 permutations
         sage: rcc.gamma_irr([4,2])
@@ -694,8 +694,8 @@ def gamma_irr(profile=None, marking=None):
 
     The non connected strata in genus 3::
 
-        sage: c_odd = AbelianStratum(2,2).odd_component()
-        sage: c_hyp = AbelianStratum(2,2).hyperelliptic_component()
+        sage: c_odd = Stratum([2,2], k=1).odd_component()
+        sage: c_hyp = Stratum([2,2], k=1).hyperelliptic_component()
         sage: c_odd.rauzy_diagram()
         Rauzy diagram with 294 permutations
         sage: c_hyp.rauzy_diagram()
@@ -703,8 +703,8 @@ def gamma_irr(profile=None, marking=None):
         sage: rcc.gamma_irr([3,3]) == 294 + 63
         True
 
-        sage: c_odd = AbelianStratum(4).odd_component()
-        sage: c_hyp = AbelianStratum(4).hyperelliptic_component()
+        sage: c_odd = Stratum([4], k=1).odd_component()
+        sage: c_hyp = Stratum([4], k=1).hyperelliptic_component()
         sage: c_odd.rauzy_diagram()
         Rauzy diagram with 134 permutations
         sage: c_hyp.rauzy_diagram()
@@ -805,10 +805,10 @@ def delta_irr(profile, marking=None):
 
     The non connected strata in genus 3::
 
-        sage: from surface_dynamics import AbelianStratum
+        sage: from surface_dynamics import Stratum
 
-        sage: c_odd = AbelianStratum(2,2).odd_component()
-        sage: c_hyp = AbelianStratum(2,2).hyperelliptic_component()
+        sage: c_odd = Stratum([2,2], k=1).odd_component()
+        sage: c_hyp = Stratum([2,2], k=1).hyperelliptic_component()
         sage: c_odd.rauzy_diagram()
         Rauzy diagram with 294 permutations
         sage: c_hyp.rauzy_diagram()
@@ -816,8 +816,8 @@ def delta_irr(profile, marking=None):
         sage: rcc.delta_irr([3,3]) == 294 - 63
         True
 
-        sage: c_odd = AbelianStratum(4).odd_component()
-        sage: c_hyp = AbelianStratum(4).hyperelliptic_component()
+        sage: c_odd = Stratum([4], k=1).odd_component()
+        sage: c_hyp = Stratum([4], k=1).hyperelliptic_component()
         sage: c_odd.rauzy_diagram()
         Rauzy diagram with 134 permutations
         sage: c_hyp.rauzy_diagram()
@@ -828,7 +828,7 @@ def delta_irr(profile, marking=None):
     A non connected strata in genus 4::
 
         sage: import surface_dynamics.interval_exchanges.rauzy_class_cardinality as rdc
-        sage: a = AbelianStratum(6)
+        sage: a = Stratum([6], k=1)
         sage: c_hyp = a.hyperelliptic_component()
         sage: c_odd = a.odd_component()
         sage: c_even = a.even_component()
@@ -852,7 +852,7 @@ def delta_irr(profile, marking=None):
 
     An example with a very big Rauzy class::
 
-        sage: c = AbelianStratum(6,6).odd_component()
+        sage: c = Stratum([6,6], k=1).odd_component()
         sage: c.rauzy_class_cardinality()
         11609364656
     """

--- a/surface_dynamics/interval_exchanges/reduced.py
+++ b/surface_dynamics/interval_exchanges/reduced.py
@@ -408,7 +408,7 @@ class ReducedPermutationIET(ReducedPermutation, OrientablePermutationIET):
                 if g == 1: # genus 1 is particular
                     nb_hyp = binomial(d,2)
                 else:
-                    k = s.nb_fake_zeros()
+                    k = s.signature().count(0)
                     d -= k
                     if extended:
                         nb_hyp = binomial(d+k,k) * (2*d-1) + binomial(d+k-1,k-1) * d

--- a/surface_dynamics/interval_exchanges/reduced.py
+++ b/surface_dynamics/interval_exchanges/reduced.py
@@ -400,8 +400,8 @@ class ReducedPermutationIET(ReducedPermutation, OrientablePermutationIET):
             return gamma_irr(p,mp.left())
 
         cc = self.stratum_component()
-        zeros = s.zeros(fake_zeros=False)
-        g = s.genus()
+        zeros = [d for d in s.signature() if d]
+        g = s.surface_genus()
         if zeros == [2*g-2] or zeros == [g-1,g-1]:  # hyp component + others
             if cc.spin() == s.hyperelliptic_component().spin():
                 d = len(self) # number of intervals of self

--- a/surface_dynamics/interval_exchanges/template.py
+++ b/surface_dynamics/interval_exchanges/template.py
@@ -5027,10 +5027,11 @@ class OrientablePermutationIET(PermutationIET):
 
             sage: p = iet.Permutation('a b c', 'c b a')
             sage: S = p.masur_polygon([1,4,2], [2,0,-1])  # optional: sage_flatsurf
+            sage: stratum = S.stratum()                   # optional: sage_flatsurf # random
+            sage: stratum                                 # optional: sage_flatsurf
+            H_1(0^2)
             sage: S                                       # optional: sage_flatsurf
             Translation Surface in H_1(0^2) built from 2 isosceles triangles and 2 triangles
-            sage: S.stratum()                             # optional: sage_flatsurf
-            H_1(0^2)
 
         Generic construction using suspension cone::
 

--- a/surface_dynamics/interval_exchanges/template.py
+++ b/surface_dynamics/interval_exchanges/template.py
@@ -125,16 +125,16 @@ def cylindric_canonical(p):
     r"""
     TESTS::
 
-        sage: from surface_dynamics import QuadraticStratum
+        sage: from surface_dynamics import Stratum
         sage: from surface_dynamics.interval_exchanges.template import cylindric_canonical
 
-        sage: C = QuadraticStratum(1,genus=0).unique_component()
+        sage: C = Stratum({1:1, -1:5}, k=2).unique_component()
         sage: R = C.permutation_representative().rauzy_diagram()
         sage: K = [p for p in R if p.is_cylindric()]
         sage: Kcan = set(cylindric_canonical(p) for p in K)
         sage: Kcan
         {((1, 0), (1, 2, 3, 4, 5, 0))}
-        sage: C = QuadraticStratum(1,1,genus=0).unique_component()
+        sage: C = Stratum({1: 2, -1: 6}, k=2).unique_component()
         sage: R = C.permutation_representative().rauzy_diagram()
         sage: K = [p for p in R if p.is_cylindric()]
         sage: Kcan = set(cylindric_canonical(p) for p in K)
@@ -3269,7 +3269,7 @@ class PermutationLI(Permutation):
 
         Check for the correspondence::
 
-            sage: q = QuadraticStratum(6,6)
+            sage: q = Stratum([6,6], k=2)
             sage: c_hyp, c_reg, c_irr = q.components()
 
             sage: p_hyp = c_hyp.permutation_representative()
@@ -3293,7 +3293,7 @@ class PermutationLI(Permutation):
             sage: p_irr.is_hyperelliptic()
             False
 
-            sage: q = QuadraticStratum(3,3,2)
+            sage: q = Stratum([3,3,2], k=2)
             sage: c_hyp, c_non_hyp = q.components()
             sage: p_hyp = c_hyp.permutation_representative()
             sage: p_hyp.is_hyperelliptic()
@@ -3301,7 +3301,7 @@ class PermutationLI(Permutation):
             sage: p_non_hyp = c_non_hyp.permutation_representative()
             sage: p_non_hyp.is_hyperelliptic()
             False
-            sage: q = QuadraticStratum(5,5,2)
+            sage: q = Stratum([5,5,2], k=2)
             sage: c_hyp, c_non_hyp = q.components()
             sage: p_hyp = c_hyp.permutation_representative()
             sage: p_hyp.is_hyperelliptic()
@@ -3309,7 +3309,7 @@ class PermutationLI(Permutation):
             sage: p_non_hyp = c_non_hyp.permutation_representative()
             sage: p_non_hyp.is_hyperelliptic()
             False
-            sage: q = QuadraticStratum(3,3,1,1)
+            sage: q = Stratum([3,3,1,1], k=2)
             sage: c_hyp, c_non_hyp = q.components()
             sage: p_hyp = c_hyp.permutation_representative()
             sage: p_hyp.is_hyperelliptic()
@@ -3320,7 +3320,7 @@ class PermutationLI(Permutation):
         """
         p = self.erase_marked_points()
         s = p.stratum()
-        zeros = s.zeros()
+        zeros = s.signature()
 
         if not s.has_hyperelliptic_component():
             return False
@@ -3414,7 +3414,7 @@ class PermutationLI(Permutation):
 
         Test the exceptional strata in genus 3::
 
-            sage: Q = QuadraticStratum(9,-1)
+            sage: Q = Stratum([9,-1], k=2)
             sage: p = Q.regular_component().permutation_representative()
             sage: p.stratum_component()
             Q_3(9, -1)^reg
@@ -3422,7 +3422,7 @@ class PermutationLI(Permutation):
             sage: p.stratum_component()
             Q_3(9, -1)^irr
 
-            sage: Q = QuadraticStratum(6,3,-1)
+            sage: Q = Stratum([6,3,-1], k=2)
             sage: p = Q.regular_component().permutation_representative()
             sage: p.stratum_component()
             Q_3(6, 3, -1)^reg
@@ -3430,7 +3430,7 @@ class PermutationLI(Permutation):
             sage: p.stratum_component()
             Q_3(6, 3, -1)^irr
 
-            sage: Q = QuadraticStratum(3,3,3,-1)
+            sage: Q = Stratum([3,3,3,-1], k=2)
             sage: p = Q.regular_component().permutation_representative()
             sage: p.stratum_component()
             Q_3(3^3, -1)^reg
@@ -3440,7 +3440,7 @@ class PermutationLI(Permutation):
 
         Test the exceptional strata in genus 4::
 
-            sage: Q = QuadraticStratum(12)
+            sage: Q = Stratum([12], k=2)
             sage: p = Q.regular_component().permutation_representative()
             sage: p.stratum_component()
             Q_4(12)^reg
@@ -3448,7 +3448,7 @@ class PermutationLI(Permutation):
             sage: p.stratum_component()
             Q_4(12)^irr
 
-            sage: Q = QuadraticStratum(9,3)
+            sage: Q = Stratum([9,3], k=2)
             sage: p = Q.regular_component().permutation_representative()
             sage: p.stratum_component()
             Q_4(9, 3)^reg
@@ -3456,7 +3456,7 @@ class PermutationLI(Permutation):
             sage: p.stratum_component()
             Q_4(9, 3)^irr
 
-            sage: Q = QuadraticStratum(6,6)
+            sage: Q = Stratum([6,6], k=2)
             sage: p = Q.hyperelliptic_component().permutation_representative()
             sage: p.stratum_component()
             Q_4(6^2)^hyp
@@ -3467,7 +3467,7 @@ class PermutationLI(Permutation):
             sage: p.stratum_component()
             Q_4(6^2)^irr
 
-            sage: Q = QuadraticStratum(6,3,3)
+            sage: Q = Stratum([6,3,3], k=2)
             sage: p = Q.regular_component().permutation_representative()
             sage: p.stratum_component()
             Q_4(6, 3^2)^reg
@@ -3475,7 +3475,7 @@ class PermutationLI(Permutation):
             sage: p.stratum_component()
             Q_4(6, 3^2)^irr
 
-            sage: Q = QuadraticStratum(3,3,3,3)
+            sage: Q = Stratum([3,3,3,3], k=2)
             sage: p = Q.hyperelliptic_component().permutation_representative()
             sage: p.stratum_component()
             Q_4(3^4)^hyp
@@ -3625,7 +3625,7 @@ class PermutationLI(Permutation):
             sage: c.stratum()
             H_1(0^4)
 
-            sage: C = QuadraticStratum(3,2,2,1).unique_component()
+            sage: C = Stratum([3,2,2,1], k=2).unique_component()
             sage: p = C.permutation_representative()
             sage: c = p.orientation_cover()
             sage: c.stratum()
@@ -3992,17 +3992,17 @@ class OrientablePermutationIET(PermutationIET):
 
         - Vincent Delecroix (2008-12-20)
         """
-        from surface_dynamics.flat_surfaces.abelian_strata import AbelianStratum
+        from surface_dynamics.flat_surfaces.abelian_strata import Stratum
 
         if not self.is_irreducible():
             return list(map(lambda x: x.stratum(), self.decompose()))
 
         if len(self) == 1:
-            return AbelianStratum([])
+            return Stratum([], k=1)
 
         singularities = [x - 1 for x in self.profile()]
 
-        return AbelianStratum(singularities)
+        return Stratum(singularities, k=1)
 
     def genus(self) :
         r"""
@@ -4148,15 +4148,15 @@ class OrientablePermutationIET(PermutationIET):
             sage: p_hyp = iet.Permutation(a,b_hyp)
             sage: p_odd = iet.Permutation(a,b_odd)
             sage: p_even = iet.Permutation(a,b_even)
-            sage: p_hyp.stratum() == AbelianStratum(4,4)
+            sage: p_hyp.stratum() == Stratum([4,4], k=1)
             True
             sage: p_hyp.stratum_component()
             H_5(4^2)^hyp
-            sage: p_odd.stratum() == AbelianStratum(4,4)
+            sage: p_odd.stratum() == Stratum([4,4], k=1)
             True
             sage: p_odd.stratum_component()
             H_5(4^2)^odd
-            sage: p_even.stratum() == AbelianStratum(4,4)
+            sage: p_even.stratum() == Stratum([4,4], k=1)
             True
             sage: p_even.stratum_component()
             H_5(4^2)^even
@@ -4174,32 +4174,29 @@ class OrientablePermutationIET(PermutationIET):
             sage: p_even.stratum_component()
             H_4(4, 2)^even
         """
-        from surface_dynamics.flat_surfaces.abelian_strata import (ASC, HypASC, NonHypASC, OddASC, EvenASC)
-
+        # TODO: we reimplement the very same logic in flat_surfaces.separatrix_diagram.stratum_component()
         if not self.is_irreducible():
             return list(map(lambda x: x.stratum_component(), self.decompose()))
 
         stratum = self.stratum()
-        cc = stratum._cc
 
-        if len(cc) == 1:
-            return stratum.components()[0]
+        if stratum.is_connected():
+            return stratum.unique_component()
 
-        if HypASC in cc:
+        if stratum.has_hyperelliptic_component():
             if self.is_hyperelliptic():
-                return HypASC(stratum)
-            else:
-                cc = cc[1:]
+                return stratum.hyperelliptic_component()
+            # TODO: we assume that the first entry is the hyperelliptic one
+            cc = stratum.connected_components()
+            if len(cc) == 2:
+                return cc[1]
 
-        if len(cc) == 1:
-            return cc[0](stratum)
-
+        # if we still have several components, they must be spin
+        spin = self.arf_invariant()
+        if spin == 0:
+            return stratum.even_component()
         else:
-            spin = self.arf_invariant()
-            if spin == 0:
-                return EvenASC(stratum)
-            else:
-                return OddASC(stratum)
+            return stratum.odd_component()
 
     def order_of_rauzy_action(self, winner, side=None):
         r"""
@@ -5232,8 +5229,8 @@ class OrientablePermutationLI(PermutationLI):
             Q_0(-1^4)
         """
         if self.is_irreducible():
-            from surface_dynamics.flat_surfaces.quadratic_strata import QuadraticStratum
-            return QuadraticStratum([x-2 for x in self.profile()])
+            from surface_dynamics.flat_surfaces.quadratic_strata import Stratum
+            return Stratum([x-2 for x in self.profile()], k=2)
         raise ValueError("stratum is well defined only for irreducible permutations")
 
 

--- a/surface_dynamics/interval_exchanges/template.py
+++ b/surface_dynamics/interval_exchanges/template.py
@@ -3248,7 +3248,7 @@ class PermutationLI(Permutation):
             ...
             NotImplementedError: not yet implemented! Do it!
         """
-        if self.stratum().nb_fake_zeros():
+        if 0 in self.stratum().signature():
             raise NotImplementedError("not yet implemented! Do it!")
         else:
             return self

--- a/tests/test_cylinder_diagrams.py
+++ b/tests/test_cylinder_diagrams.py
@@ -12,7 +12,7 @@ import pytest
 import itertools
 import random
 
-from surface_dynamics import AbelianStratum, OrigamiDatabase
+from surface_dynamics import Stratum, OrigamiDatabase
 
 def representative(cd):
     return min([cd.canonical_label(), cd.horizontal_symmetry().canonical_label(), cd.vertical_symmetry().canonical_label(), cd.inverse().canonical_label()])
@@ -73,36 +73,36 @@ def origami_check(C, sample_size, repeat):
             assert representative(o.cylinder_diagram()) in cyl_diags, o
 
 def test_H2():
-    A = AbelianStratum(2)
+    A = Stratum([2], k=1)
     cylinder_diagrams_testing(A)
     origami_check(A.unique_component(), 10, 10)
 
 def test_H11():
-    A = AbelianStratum(1,1)
+    A = Stratum([1,1], k=1)
     cylinder_diagrams_testing(A)
     origami_check(A.unique_component(), 10, 10)
 
 def test_H4():
-    A = AbelianStratum(4)
+    A = Stratum([4], k=1)
     cylinder_diagrams_testing(A)
     origami_check(A.hyperelliptic_component(), 10, 10)
     origami_check(A.odd_component(), 10, 10)
 
 @pytest.mark.slow
 def test_H22():
-    A = AbelianStratum(2,2)
+    A = Stratum([2,2], k=1)
     cylinder_diagrams_testing(A)
     origami_check(A.hyperelliptic_component(), 10, 10)
     origami_check(A.odd_component(), 10, 10)
 
 def test_H31():
-    A = AbelianStratum(3,1)
+    A = Stratum([3,1], k=1)
     cylinder_diagrams_testing(A)
     origami_check(A.unique_component(), 10, 10)
 
 @pytest.mark.slow
 def test_H6():
-    A = AbelianStratum(6)
+    A = Stratum([6], k=1)
     cylinder_diagrams_testing(A)
     origami_check(A.hyperelliptic_component(), 10, 10)
     origami_check(A.odd_component(), 10, 10)
@@ -110,6 +110,6 @@ def test_H6():
 
 @pytest.mark.slow
 def test_H211():
-    A = AbelianStratum(2,1,1)
+    A = Stratum([2,1,1], k=1)
     cylinder_diagrams_testing(A)
     origami_check(A.unique_component(), 5, 10)

--- a/tests/test_masur_veech_volumes.py
+++ b/tests/test_masur_veech_volumes.py
@@ -20,11 +20,11 @@ except ImportError:
 except cypari2.handle_error.PariError:
     pytestmark = pytest.mark.skip(reason="sage.modular.multiple_zeta not functional")
 
-from surface_dynamics import AbelianStratum
+from surface_dynamics import Stratum
 from surface_dynamics.flat_surfaces.masur_veech_volumes import masur_veech_volume
 
 def test_H2_cylinder_diagram_contributions():
-    A = AbelianStratum(2).unique_component()
+    A = Stratum([2], k=1).unique_component()
     c1 = sum(c.volume_contribution() for c in A.cylinder_diagrams(1)).integral_sum_as_mzv()
     c2 = sum(c.volume_contribution() for c in A.cylinder_diagrams(2)).integral_sum_as_mzv()
     assert c1 == M(4)/3
@@ -34,7 +34,7 @@ def test_H2_cylinder_diagram_contributions():
     assert vol == A.masur_veech_volume(rational=True) * M(2*A.stratum().genus())
 
 def test_H11_cylinder_diagram_contributions():
-    A = AbelianStratum(1,1).hyperelliptic_component()
+    A = Stratum([1,1], k=1).hyperelliptic_component()
     c1 = sum(c.volume_contribution() for c in A.cylinder_diagrams(1)).integral_sum_as_mzv()
     c2 = sum(c.volume_contribution() for c in A.cylinder_diagrams(2)).integral_sum_as_mzv()
     c3 = sum(c.volume_contribution() for c in A.cylinder_diagrams(3)).integral_sum_as_mzv()
@@ -47,7 +47,7 @@ def test_H11_cylinder_diagram_contributions():
     assert vol == A.masur_veech_volume(rational=True) * M(2*A.stratum().genus())
 
 def test_H4hyp_cylinder_diagram_contributions():
-    A = AbelianStratum(4).hyperelliptic_component()
+    A = Stratum([4], k=1).hyperelliptic_component()
     c1 = sum(c.volume_contribution() for c in A.cylinder_diagrams(1)).integral_sum_as_mzv()
     c2 = sum(c.volume_contribution() for c in A.cylinder_diagrams(2)).integral_sum_as_mzv()
     c3 = sum(c.volume_contribution() for c in A.cylinder_diagrams(3)).integral_sum_as_mzv()
@@ -56,7 +56,7 @@ def test_H4hyp_cylinder_diagram_contributions():
     assert vol == A.masur_veech_volume(rational=True) * M(2*A.stratum().genus())
 
 def test_H4odd_cylinder_diagram_contributions():
-    A = AbelianStratum(4).odd_component()
+    A = Stratum([4], k=1).odd_component()
     c1 = sum(c.volume_contribution() for c in A.cylinder_diagrams(1)).integral_sum_as_mzv()
     c2 = sum(c.volume_contribution() for c in A.cylinder_diagrams(2)).integral_sum_as_mzv()
     c3 = sum(c.volume_contribution() for c in A.cylinder_diagrams(3)).integral_sum_as_mzv()
@@ -68,7 +68,7 @@ def test_H31_cylinder_diagram_contributions():
     # values from Table 3 of A. Zorich "Square tiled surfaces
     # and Teichmueller volumes of the moduli spaces of Abelian
     # differentials" (2002)
-    A = AbelianStratum(3,1).unique_component()
+    A = Stratum([3,1], k=1).unique_component()
     c1 = sum(c.volume_contribution() for c in A.cylinder_diagrams(1)).integral_sum_as_mzv()
     c2 = sum(c.volume_contribution() for c in A.cylinder_diagrams(2)).integral_sum_as_mzv()
     c3 = sum(c.volume_contribution() for c in A.cylinder_diagrams(3)).integral_sum_as_mzv()
@@ -79,7 +79,7 @@ def test_H31_cylinder_diagram_contributions():
     vol = 16 * M(6) / 45
 
 def test_H211_cylinder_diagram_contributions():
-    A = AbelianStratum(2,1,1).unique_component()
+    A = Stratum([2,1,1], k=1).unique_component()
     c1 = sum(c.volume_contribution() for c in A.cylinder_diagrams(1)).integral_sum_as_mzv()
     c2 = sum(c.volume_contribution() for c in A.cylinder_diagrams(2)).integral_sum_as_mzv()
     c3 = sum(c.volume_contribution() for c in A.cylinder_diagrams(3)).integral_sum_as_mzv()
@@ -90,6 +90,6 @@ def test_H211_cylinder_diagram_contributions():
 
 def test_minimal_stratum_components():
     for g in range(2, 6):
-        A = AbelianStratum(2*g - 2)
+        A = Stratum([2*g - 2], k=1)
         assert sum(C.masur_veech_volume(rational=True) for C in A.components()) == A.masur_veech_volume(rational=True)
         assert sum(C.masur_veech_volume(rational=False) for C in A.components()) == A.masur_veech_volume(rational=False)

--- a/tests/test_stratum_components.py
+++ b/tests/test_stratum_components.py
@@ -10,8 +10,7 @@
 import pytest
 import random
 
-from surface_dynamics import AbelianStratum
-from surface_dynamics import QuadraticStratum
+from surface_dynamics import Stratum
 
 def check_abelian_component(C, repeat):
     for reduced in [True, False]:
@@ -43,52 +42,52 @@ def check_quadratic_component(C, repeat):
             assert p.stratum_component() == C, (reduced, p, C, ''.join(path))
 
 def test_H_6():
-    H = AbelianStratum(6)
+    H = Stratum([6], k=1)
     check_abelian_component(H.hyperelliptic_component(), 100)
     check_abelian_component(H.even_component(), 100)
     check_abelian_component(H.odd_component(), 100)
 
 def test_H_3_3():
-    H = AbelianStratum(3,3)
+    H = Stratum([3,3], k=1)
     check_abelian_component(H.hyperelliptic_component(), 100)
     check_abelian_component(H.non_hyperelliptic_component(), 100)
 
 def test_Q_6_2():
-    Q = QuadraticStratum(6, 2)
+    Q = Stratum([6, 2], k=2)
     check_quadratic_component(Q.hyperelliptic_component(), 100)
     check_quadratic_component(Q.non_hyperelliptic_component(), 100)
 
 def test_Q_9_p():
-    Q = QuadraticStratum(9, -1)
+    Q = Stratum([9, -1], k=2)
     check_quadratic_component(Q.regular_component(), 100)
     check_quadratic_component(Q.irregular_component(), 100)
 
 def test_Q_6_3_p():
-    Q = QuadraticStratum(6,3,-1)
+    Q = Stratum([6,3,-1], k=2)
     check_quadratic_component(Q.regular_component(), 100)
     check_quadratic_component(Q.irregular_component(), 100)
 
 def test_Q_12():
-    Q = QuadraticStratum(12)
+    Q = Stratum([12], k=2)
     check_quadratic_component(Q.irregular_component(), 100)
     check_quadratic_component(Q.regular_component(), 100)
 
 def testQ_6_6():
-    Q = QuadraticStratum(6,6)
+    Q = Stratum([6,6], k=2)
     check_quadratic_component(Q.hyperelliptic_component(), 100)
     check_quadratic_component(Q.regular_component(), 100)
     check_quadratic_component(Q.irregular_component(), 100)
 
 @pytest.mark.slow
 def test_Q_6_3_3():
-    Q = QuadraticStratum(6,3,3)
+    Q = Stratum([6,3,3], k=2)
     check_quadratic_component(Q.hyperelliptic_component(), 100)
     check_quadratic_component(Q.regular_component(), 100)
     check_quadratic_component(Q.irregular_component(), 100)
 
 @pytest.mark.slow
 def test_Q_3_3_3_3():
-    Q = QuadraticStratum(3,3,3,3)
+    Q = Stratum([3,3,3,3], k=2)
     check_quadratic_component(Q.hyperelliptic_component(), 100)
     check_quadratic_component(Q.regular_component(), 100)
     check_quadratic_component(Q.irregular_component(), 100)


### PR DESCRIPTION
We allow `Stratum` to handle meromorphic and higher differentials. In order to do that consistently, we factorize a lot of methods from `AbelianStratum` and `QuadraticStratum` directly in `Stratum`. Also the too specific constructors of `AbelianStratum` and `QuadraticStratum` are deprecated.

Checklist
* [x] Added an entry in `doc/news/`. <!-- Copy the TEMPLATE.rst to mybranch.rst, fill in the relevant sections, delete the others. -->
* [x] Added a test for this change.